### PR TITLE
Add FileVersionUrl to CFI schema

### DIFF
--- a/src/WopiValidator.Core/JsonSchemas/CheckFileInfoSchema.json
+++ b/src/WopiValidator.Core/JsonSchemas/CheckFileInfoSchema.json
@@ -90,6 +90,10 @@
     "FileVersionPostMessage": {
       "type": "boolean"
     },
+    "FileVersionUrl": {
+      "format": "uri",
+      "type": "string"
+    },
     "HostEditUrl": {
       "format": "uri",
       "type": "string"


### PR DESCRIPTION
Hi,

When running the Interactive WOPI validation against our WOPI host, the `CheckFileInfoSchema > FullCheckFileInfoSchema` test fails with
```
Unknown Properties: FileVersionUrl
```

Indeed, our host implements the [FileVersionUrl](https://wopi.readthedocs.io/projects/wopirest/en/latest/files/CheckFileInfo.html#term-fileversionurl) File URL property and includes it in the JSON response along with the other properties:
```
{
  ...
  "FileVersionUrl": "https://wopi.my.domain.com/myApp/xxx",
   ...
}
```
but it doesn't seem expected by the test.

I believe that it's missing in the `CheckFileInfoSchema` for the JSON schema validation, hence this PR.

Thanks!