### PR TITLE
Be more resilient to malformed server responses

### DIFF
--- a/src/WopiValidator.Core/Constants.cs
+++ b/src/WopiValidator.Core/Constants.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Office.WopiValidator.Core
 			public const string OverwriteRelative = "X-WOPI-OverwriteRelativeTarget";
 			public const string Version = "X-WOPI-ItemVersion";
 			public const string UrlType = "X-WOPI-UrlType";
+			public const string ValidatorError = "X-WOPI-ValidatorError";
 		}
 
 		public static class HeaderValues

--- a/src/WopiValidator.Core/Constants.cs
+++ b/src/WopiValidator.Core/Constants.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Office.WopiValidator.Core
 			public const string OverwriteRelative = "X-WOPI-OverwriteRelativeTarget";
 			public const string Version = "X-WOPI-ItemVersion";
 			public const string UrlType = "X-WOPI-UrlType";
+
+			// This is not an official WOPI header; it is used to pass exception information
+			// back to the validator UI. See the ExceptionHelper class for more details.
 			public const string ValidatorError = "X-WOPI-ValidatorError";
 		}
 

--- a/src/WopiValidator.Core/ExceptionHelper.cs
+++ b/src/WopiValidator.Core/ExceptionHelper.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+
+namespace Microsoft.Office.WopiValidator.Core
+{
+	class ExceptionHelper
+	{
+		private static IResponseData CustomResponseData(string exceptionMessage, string exceptionDetails)
+		{
+			var body = Encoding.UTF8.GetBytes(exceptionDetails);
+			var headers = new Dictionary<string, string> { { Constants.Headers.ValidatorError, exceptionMessage } };
+			return new ResponseData(new MemoryStream(body), (int)HttpStatusCode.Unused, headers, true, TimeSpan.Zero /* elapsed time */);
+		}
+
+		/// <summary>
+		/// This method extracts details from an Exception and wraps them in an IResponseData.
+		/// </summary>
+		///
+		/// <returns>An IResponseData object with the exception details included. The exception message
+		/// will be in Headers["X-WOPI-ValidatorError"], and more detailed information including the
+		/// stack trace will be in ResponseStream.</returns>
+		public static IResponseData WrapExceptionInResponseData(Exception ex)
+		{
+			return CustomResponseData(ex.Message, ex.ToString());
+		}
+
+		public static IResponseData WrapExceptionInResponseData(WebException ex)
+		{
+			var message = $"{ex.Status}: {ex.Message}";
+			return CustomResponseData(message, ex.ToString());
+		}
+
+	}
+}

--- a/src/WopiValidator.Core/ExceptionHelper.cs
+++ b/src/WopiValidator.Core/ExceptionHelper.cs
@@ -6,6 +6,19 @@ using System.Text;
 
 namespace Microsoft.Office.WopiValidator.Core
 {
+	/// <summary>
+	/// This class contains functions to help handle exceptions while executing tests, so that the exception
+	/// data can be displayed in the validator UI (or command line). The response code is set to
+	/// HttpStatusCode.Unused (306) in this case. The exception message is put in the X-WOPI-ValidatorError
+	/// header, and the response stream contains the stack trace (Exception.ToString).
+	///
+	/// This works in conjunction with the ExceptionValidator. That validator sees the 306 response and the
+	/// X-WOPI-ValidatorError header and fails the test, passing the exception details in the test results.
+	///
+	/// Note: This is a somewhat hacky solution (passing the exception details through a 'fake' ResponseData
+	/// that is then picked up by a Validator later), but this seems to be an unusual scenario overall and
+	/// this approach can be cleaned up and improved over time if needed.
+	/// </summary>
 	class ExceptionHelper
 	{
 		private static IResponseData CustomResponseData(string exceptionMessage, string exceptionDetails)

--- a/src/WopiValidator.Core/Factories/ValidatorFactory.cs
+++ b/src/WopiValidator.Core/Factories/ValidatorFactory.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Office.WopiValidator.Core.Validators;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
-using Microsoft.Office.WopiValidator.Core.Validators;
 
 namespace Microsoft.Office.WopiValidator.Core.Factories
 {
@@ -14,7 +13,9 @@ namespace Microsoft.Office.WopiValidator.Core.Factories
 	{
 		public static IEnumerable<IValidator> GetValidators(XElement definition)
 		{
-			return definition.Elements().Select(GetValidator);
+			var validators = new List<IValidator> { new ExceptionValidator() };
+			validators.AddRange(definition.Elements().Select(GetValidator));
+			return validators;
 		}
 
 		/// <summary>

--- a/src/WopiValidator.Core/IWopiRequest.cs
+++ b/src/WopiValidator.Core/IWopiRequest.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Office.WopiValidator.Core
 	{
 		string Name { get;  }
 		string TargetUrl { get; }
-		bool HasToBeSuccessful { get; }
 		bool IsTextResponseExpected { get; }
 		IEnumerable<KeyValuePair<string, string>> RequestHeaders { get; }
 		ProofKeyOutput CurrentProofData { get; set; }

--- a/src/WopiValidator.Core/RequestInfo.cs
+++ b/src/WopiValidator.Core/RequestInfo.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Office.WopiValidator.Core
 	{
 		public string Name { get; private set; }
 		public string TargetUrl { get; private set; }
-		public bool HasToBeSuccessful { get; private set; }
 		public IEnumerable<KeyValuePair<string, string>> RequestHeaders { get; private set; }
 		public int ResponseStatusCode { get; private set; }
 		public IEnumerable<KeyValuePair<string, string>> ResponseHeaders { get; private set; }
@@ -27,7 +26,6 @@ namespace Microsoft.Office.WopiValidator.Core
 		public RequestInfo(
 			string name,
 			string targetUrl,
-			bool hasToBeSuccessful,
 			IEnumerable<KeyValuePair<string, string>> requestHeaders,
 			int responseStatusCode,
 			IEnumerable<KeyValuePair<string, string>> responseHeaders,
@@ -39,7 +37,6 @@ namespace Microsoft.Office.WopiValidator.Core
 		{
 			Name = name;
 			TargetUrl = targetUrl;
-			HasToBeSuccessful = hasToBeSuccessful;
 			RequestHeaders = requestHeaders ?? Enumerable.Empty<KeyValuePair<string, string>>();
 			ResponseStatusCode = responseStatusCode;
 			ResponseHeaders = responseHeaders ?? Enumerable.Empty<KeyValuePair<string, string>>();

--- a/src/WopiValidator.Core/TestCaseExecutor.cs
+++ b/src/WopiValidator.Core/TestCaseExecutor.cs
@@ -100,7 +100,6 @@ namespace Microsoft.Office.WopiValidator.Core
 					RequestInfo requestInfo = new RequestInfo(
 						request.Name,
 						request.TargetUrl,
-						request.HasToBeSuccessful,
 						request.RequestHeaders,
 						responseData.StatusCode,
 						responseData.Headers,
@@ -216,7 +215,6 @@ namespace Microsoft.Office.WopiValidator.Core
 					RequestInfo requestInfo = new RequestInfo(
 						request.Name,
 						request.TargetUrl,
-						request.HasToBeSuccessful,
 						request.RequestHeaders,
 						responseData.StatusCode,
 						responseData.Headers,
@@ -236,7 +234,6 @@ namespace Microsoft.Office.WopiValidator.Core
 					RequestInfo requestInfo = new RequestInfo(
 						request.Name,
 						request.TargetUrl,
-						request.HasToBeSuccessful,
 						request.RequestHeaders,
 						0,
 						Enumerable.Empty<KeyValuePair<string, string>>(),

--- a/src/WopiValidator.Core/Validators/ExceptionValidator.cs
+++ b/src/WopiValidator.Core/Validators/ExceptionValidator.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Net;
+
+namespace Microsoft.Office.WopiValidator.Core.Validators
+{
+	/// <summary>
+	/// Validates that no unhandled WebExceptions were thrown while handling a response.
+	/// If an unhandled exception is thrown, it is caught and the exception details are
+	/// inserted into the response headers.
+	///
+	/// This validator is included on every request; it does not need to be explicitly added
+	/// to the test case definition XML.
+	/// </summary>
+	class ExceptionValidator : IValidator
+	{
+		public string Name { get { return "ExceptionValidator"; } }
+
+		public ValidationResult Validate(IResponseData data, IResourceManager resourceManager, Dictionary<string, string> savedState)
+		{
+			if (data.StatusCode == (int)HttpStatusCode.Unused &&
+				data.Headers.ContainsKey(Constants.Headers.ValidatorError))
+			{
+				return new ValidationResult(data.Headers[Constants.Headers.ValidatorError]);
+			}
+
+			return new ValidationResult();
+		}
+	}
+}


### PR DESCRIPTION
We have seen cases where servers send malformed HTTP responses to WOPI requests. This causes a WebException to be thrown, which is caught by the validator. However, we were trying to then access WebException.Response in cases where it was null. The first part of this change ensures we only retrieve the Response from the WebException when it's populated.

I also made a utility function to take an Exception and wrap its details in a IResponseData object. That way the exception data can be displayed in the validator UI (or command line). The response code is set to HttpStatusCode.Unused (306) in this case. The exception message is put in the X-WOPI-ValidatorError header, and the response stream contains the stack trace (`Exception.ToString`).

I then added an 'always on' validator that checks for the 306 response code and the presence of the X-WOPI-ValidatorError header. It marks the test as failed if these conditions are met, and passes the exception message back in the test failure message. This should help WOPI server implementers determine what responses are malformed so they can fix their server.

Finally, there was a HasToBeSuccessful property on IRequest that was never set to true as far as I can tell. It was confusing because the value was checked in at least one place in code (the WebException handler), but it was never set to true as far as I could tell. I removed the property.