### PR TITLE
Update ProofKeyMutator to account for WopiTimestamp mutations

### DIFF
--- a/src/WopiValidator.Core/Mutators/ProofKeyMutator.cs
+++ b/src/WopiValidator.Core/Mutators/ProofKeyMutator.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Office.WopiValidator.Core.Mutators
 			Dictionary<string, string> originalProofKeyHeaders,
 			Func<long, Dictionary<string, string>> proofKeyGeneration)
 		{
+			// if we're mutating the wopi timestamp we have to regenerate the entire proofKey data before doing other mutations.
 			Dictionary<string, string> proofKeyHeaders
 				= WopiTimestamp != null ? proofKeyGeneration(WopiTimestamp.Value) : new Dictionary<string, string>(originalProofKeyHeaders);
 			

--- a/src/WopiValidator.Core/Mutators/ProofKeyMutator.cs
+++ b/src/WopiValidator.Core/Mutators/ProofKeyMutator.cs
@@ -56,32 +56,25 @@ namespace Microsoft.Office.WopiValidator.Core.Mutators
 			Dictionary<string, string> originalProofKeyHeaders,
 			Func<long, Dictionary<string, string>> proofKeyGeneration)
 		{
-			Dictionary<string, string> proofKeyHeaders;
-
-			if (WopiTimestamp != null && proofKeyGeneration != null)
-			{
-				proofKeyHeaders = proofKeyGeneration(WopiTimestamp.Value);
-			}
-			else
-			{
-				proofKeyHeaders = new Dictionary<string, string>(3);
-				proofKeyHeaders[Constants.Headers.WopiTimestamp] = originalProofKeyHeaders[Constants.Headers.WopiTimestamp];
-			}
+			Dictionary<string, string> proofKeyHeaders
+				= WopiTimestamp != null ? proofKeyGeneration(WopiTimestamp.Value) : new Dictionary<string, string>(originalProofKeyHeaders);
 			
 			switch (KeyRelation)
 			{
 				case KeyRelationType.Synced:
-					proofKeyHeaders[Constants.Headers.ProofKey] = MutateCurrent
-						? InvalidBase64String : originalProofKeyHeaders[Constants.Headers.ProofKey];
-					proofKeyHeaders[Constants.Headers.ProofKeyOld] = MutateOld
-						? InvalidBase64String : originalProofKeyHeaders[Constants.Headers.ProofKeyOld];
+					if (MutateCurrent)
+						proofKeyHeaders[Constants.Headers.ProofKey] = InvalidBase64String;
+					if (MutateOld)
+						proofKeyHeaders[Constants.Headers.ProofKeyOld] = InvalidBase64String;
 					break;
+
 				case KeyRelationType.Behind:
-					proofKeyHeaders[Constants.Headers.ProofKey] = originalProofKeyHeaders[Constants.Headers.ProofKeyOld];
+					proofKeyHeaders[Constants.Headers.ProofKey] = proofKeyHeaders[Constants.Headers.ProofKeyOld];
 					proofKeyHeaders[Constants.Headers.ProofKeyOld] = InvalidBase64String;
 					break;
+
 				case KeyRelationType.Ahead:
-					proofKeyHeaders[Constants.Headers.ProofKeyOld] = originalProofKeyHeaders[Constants.Headers.ProofKey];
+					proofKeyHeaders[Constants.Headers.ProofKeyOld] = proofKeyHeaders[Constants.Headers.ProofKey];
 					proofKeyHeaders[Constants.Headers.ProofKey] = InvalidBase64String;
 					break;
 			}

--- a/test/WopiValidator.Core.Tests/Mutators/ProofKeyMutatorTests.cs
+++ b/test/WopiValidator.Core.Tests/Mutators/ProofKeyMutatorTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Office.WopiValidator.UnitTests.Mutators
 			ProofKeyMutator mutator = new ProofKeyMutator(mutateCurrent, mutateOld, timestamp, keyRelation);
 
 			// Act
-			Dictionary<string, string> mutatedHeaders = mutator.Mutate(originalHeaders);
+			Dictionary<string, string> mutatedHeaders = mutator.Mutate(originalHeaders, proofKeyGeneration: CreateProofKeyHeadersWithMutatedTimestamp);
 
 			// Assert
 			Assert.AreEqual(CurrentProofKey, mutatedHeaders[Constants.Headers.ProofKey]);
@@ -54,7 +54,7 @@ namespace Microsoft.Office.WopiValidator.UnitTests.Mutators
 			ProofKeyMutator mutator = new ProofKeyMutator(mutateCurrent, mutateOld, MutatedWopiTimestampString, keyRelation);
 
 			// Act
-			Dictionary<string, string> mutatedHeaders = mutator.Mutate(originalHeaders);
+			Dictionary<string, string> mutatedHeaders = mutator.Mutate(originalHeaders, proofKeyGeneration: CreateProofKeyHeadersWithMutatedTimestamp);
 
 			// Assert
 			Assert.AreEqual(ProofKeyMutator.InvalidBase64String, mutatedHeaders[Constants.Headers.ProofKey]);
@@ -77,7 +77,7 @@ namespace Microsoft.Office.WopiValidator.UnitTests.Mutators
 				ProofKeyMutator.KeyRelationType.Ahead);
 
 			// Act
-			Dictionary<string, string> mutatedHeaders = mutator.Mutate(originalHeaders);
+			Dictionary<string, string> mutatedHeaders = mutator.Mutate(originalHeaders, proofKeyGeneration: CreateProofKeyHeadersWithMutatedTimestamp);
 
 			// Assert
 			Assert.AreEqual(ProofKeyMutator.InvalidBase64String, mutatedHeaders[Constants.Headers.ProofKey]);
@@ -100,7 +100,7 @@ namespace Microsoft.Office.WopiValidator.UnitTests.Mutators
 				ProofKeyMutator.KeyRelationType.Behind);
 
 			// Act
-			Dictionary<string, string> mutatedHeaders = mutator.Mutate(originalHeaders);
+			Dictionary<string, string> mutatedHeaders = mutator.Mutate(originalHeaders, proofKeyGeneration: CreateProofKeyHeadersWithMutatedTimestamp);
 
 			// Assert
 			Assert.AreEqual(OldProofKey, mutatedHeaders[Constants.Headers.ProofKey]);
@@ -123,7 +123,7 @@ namespace Microsoft.Office.WopiValidator.UnitTests.Mutators
 				ProofKeyMutator.KeyRelationType.Ahead);
 
 			// Act
-			Dictionary<string, string> mutatedHeaders = mutator.Mutate(originalHeaders);
+			Dictionary<string, string> mutatedHeaders = mutator.Mutate(originalHeaders, proofKeyGeneration: CreateProofKeyHeadersWithMutatedTimestamp);
 
 			// Assert
 			Assert.AreEqual(ProofKeyMutator.InvalidBase64String, mutatedHeaders[Constants.Headers.ProofKey]);
@@ -146,7 +146,7 @@ namespace Microsoft.Office.WopiValidator.UnitTests.Mutators
 				ProofKeyMutator.KeyRelationType.Behind);
 
 			// Act
-			Dictionary<string, string> mutatedHeaders = mutator.Mutate(originalHeaders);
+			Dictionary<string, string> mutatedHeaders = mutator.Mutate(originalHeaders, proofKeyGeneration: CreateProofKeyHeadersWithMutatedTimestamp);
 
 			// Assert
 			Assert.AreEqual(OldProofKey, mutatedHeaders[Constants.Headers.ProofKey]);
@@ -161,6 +161,16 @@ namespace Microsoft.Office.WopiValidator.UnitTests.Mutators
 				{ Constants.Headers.ProofKey, CurrentProofKey },
 				{ Constants.Headers.ProofKeyOld, OldProofKey },
 				{ Constants.Headers.WopiTimestamp, WopiTimestamp }
+			};
+		}
+
+		private static Dictionary<string, string> CreateProofKeyHeadersWithMutatedTimestamp(long timestamp)
+		{
+			return new Dictionary<string, string>()
+			{
+				{ Constants.Headers.ProofKey, CurrentProofKey },
+				{ Constants.Headers.ProofKeyOld, OldProofKey },
+				{ Constants.Headers.WopiTimestamp, timestamp.ToString(System.Globalization.CultureInfo.InstalledUICulture) }
 			};
 		}
 	}


### PR DESCRIPTION
Not sure if that's the best way to solve the problem, but should do.

It would be great to add a UT which covers the scenario (fails before the change, passes after).
