### PR TITLE
Rename ExpectedDocumentId to ExpectedResourceId

### DIFF
--- a/TestCases.xml
+++ b/TestCases.xml
@@ -961,7 +961,7 @@
           <PutFile ResourceId="WordBlankDocument" />
           <GetFile>
             <Validators>
-              <ResponseContentValidator ExpectedDocumentId="WordBlankDocument" />
+              <ResponseContentValidator ExpectedResourceId="WordBlankDocument" />
             </Validators>
           </GetFile>
         </Requests>
@@ -3452,7 +3452,7 @@
           <Unlock Lock="LockString" />
           <GetFromFileUrl OverrideUrl="$State:FileUrl">
             <Validators>
-              <ResponseContentValidator ExpectedDocumentId="WordSimpleDocument" />
+              <ResponseContentValidator ExpectedResourceId="WordSimpleDocument" />
             </Validators>
           </GetFromFileUrl>
         </Requests>

--- a/TestCases.xml
+++ b/TestCases.xml
@@ -10,7 +10,7 @@
     <File Id="ZeroByteFile" Name="ZeroByteFile.wopitest" FilePath="Resources\ZeroByteFile.wopitest" />
   </Resources>
   <PrereqCases>
-    <TestCase Name="WopiValidatorPrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="WopiValidatorPrereq" Category="WopiCore">
       <Description>
         The prereq WOPI validation that must pass prior to running the (potentially destructive) test suite.
       </Description>
@@ -25,7 +25,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="UserCanWritePrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="UserCanWritePrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if the user has permission to perform Write operation.
       </Description>
@@ -40,7 +40,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="UserCanNotWriteRelativePrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="UserCanNotWriteRelativePrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if the user is denied permission to call PutRelativeFile.
       </Description>
@@ -55,7 +55,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="UserCanWriteRelativePrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="UserCanWriteRelativePrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if the user has permission to call PutRelativeFile.
       </Description>
@@ -70,7 +70,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="ContainersPrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="ContainersPrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if the host declares support for Containers operations.
       </Description>
@@ -85,7 +85,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="ContainersUnsupportedPrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="ContainersUnsupportedPrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check that the host does NOT support Containers operations.
         This can be used in cases where a test group should be skipped if the host DOES support Containers
@@ -102,7 +102,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="EcosystemPrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="EcosystemPrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if the host declares support for Ecosystem operations.
       </Description>
@@ -117,7 +117,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="LocksPrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="LocksPrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if the host declares support for Lock/Unlock/RefreshLock/UnlockAndRefreshLock
         operations.
@@ -133,7 +133,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="FileEditingPrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="FileEditingPrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if host declares support for PutFile/PutRelativeFile operations.
       </Description>
@@ -148,7 +148,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="GetLockPrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="GetLockPrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if host declares support for GetLock operation.
       </Description>
@@ -163,7 +163,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="ExtendedLockLengthPrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="ExtendedLockLengthPrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if host declares support for extended lock lengths.
       </Description>
@@ -178,7 +178,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="BusinessFlowPrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="BusinessFlowPrereq" Category="WopiCore">
       <Description>
         The prereq BusinessFlowPrereq must pass prior to running the feature validations related to business flows.
       </Description>
@@ -193,7 +193,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="DeleteFilePrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="DeleteFilePrereq" Category="WopiCore">
       <Description>
         The host must support /files/DeleteFile.
       </Description>
@@ -208,7 +208,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="FileUrlUsagePrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="FileUrlUsagePrereq" Category="WopiCore">
       <Description>
         The host uses FileUrl for direct file access.
       </Description>
@@ -223,7 +223,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="SupportedShareUrlTypesForFilePrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="SupportedShareUrlTypesForFilePrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if the host sets SupportedShareUrlTypes in CheckFileInfo to any value.
       </Description>
@@ -238,7 +238,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="ShareUrlTypeReadOnlyForFilePrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="ShareUrlTypeReadOnlyForFilePrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if the host declares support for the "ReadOnly" Share Url type for the file.
       </Description>
@@ -253,7 +253,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="ShareUrlTypeReadWriteForFilePrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="ShareUrlTypeReadWriteForFilePrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if the host declares support for the "ReadWrite" Share Url type for the file.
       </Description>
@@ -268,7 +268,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="SupportedShareUrlTypesForContainerPrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="SupportedShareUrlTypesForContainerPrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if the host sets SupportedShareUrlTypes in CheckContainerInfo to any value.
       </Description>
@@ -289,7 +289,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="ShareUrlTypeReadOnlyForContainerPrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="ShareUrlTypeReadOnlyForContainerPrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if the host declares support for the "ReadOnly" Share Url type for the container.
       </Description>
@@ -310,7 +310,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="ShareUrlTypeReadWriteForContainerPrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="ShareUrlTypeReadWriteForContainerPrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if the host declares support for the "ReadWrite" Share Url type for the container.
       </Description>
@@ -331,7 +331,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="RenameFilePrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="RenameFilePrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if host declares support for RenameFile operation.
       </Description>
@@ -346,7 +346,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="UserCanCreateChildFilePrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="UserCanCreateChildFilePrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if the user has permission to call CreateChildFile operation.
       </Description>
@@ -367,7 +367,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="AddActivitiesPrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="AddActivitiesPrereq" Category="WopiCore">
       <Description>
         The host must support /files/AddActivities.
       </Description>
@@ -382,7 +382,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="UserCanRenameContainerPrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="UserCanRenameContainerPrereq" Category="WopiCore">
       <Description>
         Prereq WOPI Validation test to check if the user has permissions to call RenameContainer.
       </Description>
@@ -402,7 +402,7 @@
       </Requests>
     </TestCase>
 
-    <TestCase Name="SupportsUserInfoPrereq" Document="WordBlankDocument" Category="WopiCore">
+    <TestCase Name="SupportsUserInfoPrereq" Category="WopiCore">
       <Description>
         The host must support /files/PutUserInfo.
       </Description>
@@ -424,7 +424,7 @@
       <PrereqTest>WopiValidatorPrereq</PrereqTest>
     </PrereqTests>
     <TestCases>
-      <TestCase Name="FullCheckFileInfoSchema" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="FullCheckFileInfoSchema" Category="WopiCore">
         <Description>
           This tests that hosts' CheckFileInfo responses conform to the JSON schema.
         </Description>
@@ -440,7 +440,7 @@
           </CheckFileInfo>
         </Requests>
       </TestCase>
-      <TestCase Name="HostUrls" Document="WordBlankDocument" Category="OfficeOnline">
+      <TestCase Name="HostUrls" Category="OfficeOnline">
         <Description>
           This tests that the Host* URLs provided by the host are not Office Online action URLs.
         </Description>
@@ -466,7 +466,7 @@
       </TestCase>
 
       <!-- Access token related testcases -->
-      <TestCase Name="CheckFileWithInvalidAccessToken" Document="WordSimpleDocument" Category="WopiCore">
+      <TestCase Name="CheckFileWithInvalidAccessToken" Category="WopiCore">
         <Description>
           Simulates a CheckFileInfo request with invalid access token and expects a 401 or 404 response.
         </Description>
@@ -493,7 +493,7 @@
     </PrereqTests>
     <!-- Full Viewer app sequences -->
     <TestCases>
-      <TestCase Name="ViewOnlySupport" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="ViewOnlySupport" Category="WopiCore">
         <Description>
           Standard sequence of requests made by a WOPI client to render a document.
         </Description>
@@ -520,7 +520,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="GetUnlockedFile" Document="WordSimpleDocument" Category="WopiCore">
+      <TestCase Name="GetUnlockedFile" Category="WopiCore">
         <Description>
           GetFile requests on a file that wasn't locked before - necessary for Viewing and Editing.
         </Description>
@@ -539,7 +539,7 @@
     </PrereqTests>
     <TestCases>
       <!-- Lock length validation -->
-      <TestCase Name="LockLengthValidation" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="LockLengthValidation" Category="WopiCore">
         <Description>
           Tests that the WOPI host is capable of handling WOPI Lock IDs of 256 characters.
         </Description>
@@ -553,7 +553,7 @@
       </TestCase>
 
       <!-- Lock format validation -->
-      <TestCase Name="LockFormatValidation" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="LockFormatValidation" Category="WopiCore">
         <Description>
           Tests that Office locks, which happen to be JSON-formatted strings today, are handled properly by the host.
         </Description>
@@ -567,7 +567,7 @@
       </TestCase>
 
       <!-- Lock requests -->
-      <TestCase Name="SuccessfulLockSequence" Document="WordSimpleDocument" Category="WopiCore">
+      <TestCase Name="SuccessfulLockSequence" Category="WopiCore">
         <Description>
           Simulates a successful sequence of lock-related requests: Lock, RefreshLock, UnlockAndRelock, Unlock.
         </Description>
@@ -583,7 +583,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="LockMismatchAfterUnlockAndRelockRequest" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="LockMismatchAfterUnlockAndRelockRequest" Category="WopiCore">
         <Description>
           Simulates a successful UnlockAndRelock followed by Unlock with old lock. This tests that UnlockAndRelock actually changes the lock string
         </Description>
@@ -603,7 +603,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="DoubleLockSequence" Document="WordSimpleDocument" Category="WopiCore">
+      <TestCase Name="DoubleLockSequence" Category="WopiCore">
         <Description>
           Two Lock calls in a row with the same Lock ID should work.
         </Description>
@@ -617,7 +617,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="UnlockUnlockedFile" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="UnlockUnlockedFile" Category="WopiCore">
         <Description>
           Responses to Unlock requests on an unlocked file should include the X-WOPI-Lock header set to the empty string.
         </Description>
@@ -634,7 +634,7 @@
       </TestCase>
 
       <!-- LockMismatch -->
-      <TestCase Name="LockMismatchOnLockRequest" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="LockMismatchOnLockRequest" Category="WopiCore">
         <Description>
           Simulates a lock mismatch when trying to refresh the lock.
           Validates that the current lock ID is returned as response header.
@@ -654,7 +654,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="LockMismatchOnUnlockRequest" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="LockMismatchOnUnlockRequest" Category="WopiCore">
         <Description>
           Simulates a lock mismatch when trying to unlock the file.
           Validates that the current lock ID is returned as response header.
@@ -674,7 +674,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="LockMismatchOnRefreshLockRequest" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="LockMismatchOnRefreshLockRequest" Category="WopiCore">
         <Description>
           Simulates a lock mismatch when trying to refresh the lock.
           Validates that the current lock ID is returned as response header.
@@ -694,7 +694,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="LockMismatchOnUnlockAndRelockRequest" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="LockMismatchOnUnlockAndRelockRequest" Category="WopiCore">
         <Description>
           Simulates a lock mismatch when trying to unlock and relock the file.
           Validates that the current lock ID is returned as response header.
@@ -715,7 +715,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="LockMismatchOnPutFileRequest" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="LockMismatchOnPutFileRequest" Category="WopiCore">
         <Description>
           Simulates a lock mismatch when trying to refresh the lock.
           Validates that the current lock ID is returned as response header.
@@ -736,7 +736,7 @@
       </TestCase>
 
       <!-- Invalid access token on Lock requests -->
-      <TestCase Name="LockFileWithInvalidAccessToken" Document="WordSimpleDocument" Category="WopiCore">
+      <TestCase Name="LockFileWithInvalidAccessToken" Category="WopiCore">
         <Description>
           Tests Lock operation with an invalid access token and expects a 401 or 404 response.
         </Description>
@@ -759,7 +759,7 @@
       </TestCase>
 
       <!-- Invalid access token on Unlock requests -->
-      <TestCase Name="UnlockFileWithInvalidAccessToken" Document="WordSimpleDocument" Category="WopiCore">
+      <TestCase Name="UnlockFileWithInvalidAccessToken" Category="WopiCore">
         <Description>
           Tests Unlock operation with an invalid access token and expects a 401 or 404 response.
         </Description>
@@ -795,7 +795,7 @@
     </PrereqTests>
     <TestCases>
       <!-- /files/GetLock -->
-      <TestCase Name="files.GetLock" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.GetLock" Category="WopiCore">
         <Description>
           Tests the standard GetLock flow; Lock, GetLock, then Unlock.
         </Description>
@@ -812,7 +812,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="files.GetLockAfterChange" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.GetLockAfterChange" Category="WopiCore">
         <Description>
           Tests that the lock ID GetLock returns changes after it's changed by UnlockAndRelock.
         </Description>
@@ -830,7 +830,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="files.GetLockOnUnlockedFile" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.GetLockOnUnlockedFile" Category="WopiCore">
         <Description>
           Tests GetLock after a file has been locked and unlocked.
         </Description>
@@ -857,7 +857,7 @@
     </PrereqTests>
     <TestCases>
       <!-- /files/Lock: test new 1024 character lock length -->
-      <TestCase Name="files.ExtendedLockLengthValidation" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.ExtendedLockLengthValidation" Category="WopiCore">
         <Description>
           Tests that the WOPI host is capable of handling WOPI Lock IDs of 1024 characters.
         </Description>
@@ -888,7 +888,7 @@
       <PrereqTest>LocksPrereq</PrereqTest>
     </PrereqTests>
     <TestCases>
-      <TestCase Name="BasicEdit" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="BasicEdit" Category="WopiCore">
         <Description>
           Standard sequence of requests made by an edit-capable WOPI client as part of application boot and successful saves when user interacts with the document.
         </Description>
@@ -915,13 +915,18 @@
           <GetFile Lock="LockString" />
           <PutFile Lock="LockString" ResourceId="WordSimpleDocument" />
           <Unlock Lock="LockString" />
+          <GetFile>
+            <Validators>
+              <ResponseContentValidator ExpectedResourceId="WordSimpleDocument" />
+            </Validators>
+          </GetFile>
         </Requests>
         <CleanupRequests>
           <Unlock Lock="LockString" />
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="EditNoChange" Document="WordSimpleDocument" Category="WopiCore">
+      <TestCase Name="EditNoChange" Category="WopiCore">
         <Description>
           Simulates an editor boot and save with no changes to a file.
         </Description>
@@ -947,7 +952,7 @@
       </TestCase>
 
       <!-- Requests to unlocked file -->
-      <TestCase Name="PutUnlockedFile" Document="WordZeroByteDocument" Category="WopiCore">
+      <TestCase Name="PutUnlockedFile" Category="WopiCore">
         <Description>
           Simulates creating a new file on the host, which requires PutFile requests to an unlocked 0-byte file to succeed.
         </Description>
@@ -971,7 +976,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutUnlockedFileNotZeroBytes" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutUnlockedFileNotZeroBytes" Category="WopiCore">
         <Description>
           This tests that PutFile requests fail when executed against files that are not zero bytes.
         </Description>
@@ -994,7 +999,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="GetPutFileWithInvalidAccessToken" Document="WordSimpleDocument" Category="WopiCore">
+      <TestCase Name="GetPutFileWithInvalidAccessToken" Category="WopiCore">
         <Description>
           Simulates Get and PutFile requests with invalid access token and expects a 401 or 404 response.
         </Description>
@@ -1042,7 +1047,7 @@
     <TestCases>
 
       <!-- /files/GetFile returns X-WOPI-ItemVersion -->
-      <TestCase Name="files.GetFileReturnsVersion" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.GetFileReturnsVersion" Category="WopiCore">
         <Description>
           /files/GetFile should return the current version of the file
         </Description>
@@ -1056,7 +1061,7 @@
       </TestCase>
 
       <!-- /files/Lock and /files/Unlock return X-WOPI-ItemVersion -->
-      <TestCase Name="files.LockReturnsVersion" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.LockReturnsVersion" Category="WopiCore">
         <Description>
           /files/Lock should return the current version of the file
         </Description>
@@ -1073,7 +1078,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="files.UnlockReturnsVersion" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.UnlockReturnsVersion" Category="WopiCore">
         <Description>
           /files/Unlock should return the current version of the file
         </Description>
@@ -1091,7 +1096,7 @@
       </TestCase>
 
       <!-- /files/PutFile returns X-WOPI-ItemVersion -->
-      <TestCase Name="files.PutFileReturnsVersion" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.PutFileReturnsVersion" Category="WopiCore">
         <Description>
           /files/PutFile should return the current version of the file
         </Description>
@@ -1110,7 +1115,7 @@
       </TestCase>
 
       <!-- /files/PutFile returns a different X-WOPI-ItemVersion -->
-      <TestCase Name="files.PutFileReturnsDifferentVersion" Document="WordBlankDocument" Category="OfficeNativeClient">
+      <TestCase Name="files.PutFileReturnsDifferentVersion" Category="OfficeNativeClient">
         <Description>
           Performs consecutive PutFile operations to verify that the X-WOPI-ItemVersion header value is changed with every PutFile operation.
         </Description>
@@ -1142,7 +1147,7 @@
       </TestCase>
 
       <!-- /files/GetFile, /files/Lock and /files/Unlock returns the same X-WOPI-ItemVersion -->
-      <TestCase Name="files.LockAndUnlockAfterGetFileReturnsSameVersion" Document="WordBlankDocument" Category="OfficeNativeClient">
+      <TestCase Name="files.LockAndUnlockAfterGetFileReturnsSameVersion" Category="OfficeNativeClient">
         <Description>
           Performs Lock and Unlock operations after a GetFile operation to verify that the X-WOPI-ItemVersion header value is unchanged.
         </Description>
@@ -1184,7 +1189,7 @@
     <TestCases>
 
       <!-- PutUserInfo call returns 200 and subsequent CheckFileInfo calls return the correct value -->
-      <TestCase Name="PutUserInfoSucceeds" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutUserInfoSucceeds" Category="WopiCore">
         <Description>
           PutUserInfo call returns 200 and subsequent CheckFileInfo calls return the correct value
         </Description>
@@ -1218,7 +1223,7 @@
       <PrereqTest>DeleteFilePrereq</PrereqTest>
     </PrereqTests>
     <TestCases>
-      <TestCase Name="PutRelativeFile.SuggestedExtension" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFile.SuggestedExtension" Category="WopiCore">
         <Description>
           Tests the basic PutRelativeFile scenario where a suggested extension is specified.
         </Description>
@@ -1243,7 +1248,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFile.SuggestedName" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFile.SuggestedName" Category="WopiCore">
         <Description>
           Tests the basic PutRelativeFile scenario where a suggested name is specified.
         </Description>
@@ -1268,7 +1273,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFile.SuggestedNameConflict" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFile.SuggestedNameConflict" Category="WopiCore">
         <Description>
           Tests the PutRelativeFile scenario where a suggested name is specified but
           a file with the target name already exists. Expects the request to succeed with the host
@@ -1310,7 +1315,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFile.RelativeName" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFile.RelativeName" Category="WopiCore">
         <Description>
           Tests the PutRelativeFile scenario where a Relative name is specified. Expects the created file to have
           the exact name specified.
@@ -1336,7 +1341,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFile.RelativeNameOverwriteTrueNoEffect" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFile.RelativeNameOverwriteTrueNoEffect" Category="WopiCore">
         <Description>
           Tests the PutRelativeFile scenario where a Relative name is specified and OverwriteRelative
           is set to true. Since no file with target name exists in this scenario, the header should have
@@ -1363,7 +1368,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFile.RelativeNameOverwriteFalseNoEffect" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFile.RelativeNameOverwriteFalseNoEffect" Category="WopiCore">
         <Description>
           Tests the PutRelativeFile scenario where a Relative name is specified and OverwriteRelative
           is set to false. Since no file with target name exists in this scenario, the header should have
@@ -1390,7 +1395,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFile.RelativeNameConflictNoOverwrite" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFile.RelativeNameConflictNoOverwrite" Category="WopiCore">
         <Description>
           Tests the PutRelativeFile scenario where a Relative name is specified and OverwriteRelative
           is not specified. Since a file with target name exists in this scenario, this should return a 409.
@@ -1421,7 +1426,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFile.RelativeNameConflictOverwriteFalse" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFile.RelativeNameConflictOverwriteFalse" Category="WopiCore">
         <Description>
           Tests the PutRelativeFile scenario where a Relative name is specified and OverwriteRelative
           is set to false. Since a file with target name exists in this scenario, this should return a 409.
@@ -1452,7 +1457,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFile.RelativeNameConflictOverwriteTrue" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFile.RelativeNameConflictOverwriteTrue" Category="WopiCore">
         <Description>
           Tests the PutRelativeFile scenario where a Relative name is specified and OverwriteRelative is set to true.
         </Description>
@@ -1496,7 +1501,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFile.ConflictingHeaders" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFile.ConflictingHeaders" Category="WopiCore">
         <Description>
           Tests the PutRelativeFile scenario where both a suggested name and a relative name are specified.
         </Description>
@@ -1513,7 +1518,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFile.RelativeNameConflictOverwriteTrueLocked" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFile.RelativeNameConflictOverwriteTrueLocked" Category="WopiCore">
         <Description>
           Tests the PutRelativeFile scenario where a relative name is specified along with OverwriteRelative
           set to true, but a file with the same target name already exists and is locked.
@@ -1546,7 +1551,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFile.FileNameReturnedIsCorrectlyEncoded" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFile.FileNameReturnedIsCorrectlyEncoded" Category="WopiCore">
         <Description>
           Tests that the host returns a UTF-8 encoded version of the FileName after a PutRelativeFile operation.
         </Description>
@@ -1568,7 +1573,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFile.FileNameLongerThan512Chars" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFile.FileNameLongerThan512Chars" Category="WopiCore">
         <Description>
           Tests that the host handles long file names appropriately by either supporting them or returning a 400.
         </Description>
@@ -1591,7 +1596,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFile.IncludeHostUrls" Document="WordBlankDocument" Category="OfficeOnline">
+      <TestCase Name="PutRelativeFile.IncludeHostUrls" Category="OfficeOnline">
         <Description>
           Tests that the host returns the HostEditUrl and HostViewUrl on their PutRelativeFile response.
         </Description>
@@ -1624,7 +1629,7 @@
       <PrereqTest>UserCanNotWriteRelativePrereq</PrereqTest>
     </PrereqTests>
     <TestCases>
-      <TestCase Name="PutRelativeFileUnsupported.SuggestedExtension" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFileUnsupported.SuggestedExtension" Category="WopiCore">
         <Description>
           Tests the basic PutRelativeFile scenario where a suggested extension is specified.
         </Description>
@@ -1638,7 +1643,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFileUnsupported.SuggestedName" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFileUnsupported.SuggestedName" Category="WopiCore">
         <Description>
           Tests the basic PutRelativeFile scenario where a suggested name is specified.
         </Description>
@@ -1652,7 +1657,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFileUnsupported.RelativeName" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFileUnsupported.RelativeName" Category="WopiCore">
         <Description>
           Tests the PutRelativeFile scenario where a Relative name is specified.
         </Description>
@@ -1666,7 +1671,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFileUnsupported.RelativeNameOverwriteTrueNoEffect" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFileUnsupported.RelativeNameOverwriteTrueNoEffect" Category="WopiCore">
         <Description>
           Tests the PutRelativeFile scenario where a Relative name is specified and OverwriteRelative is set to true.
         </Description>
@@ -1680,7 +1685,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFileUnsupported.RelativeNameOverwriteFalseNoEffect" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFileUnsupported.RelativeNameOverwriteFalseNoEffect" Category="WopiCore">
         <Description>
           Tests the PutRelativeFile scenario where a Relative name is specified and OverwriteRelative is set to false.
         </Description>
@@ -1694,7 +1699,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="PutRelativeFileUnsupported.ConflictingHeaders" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeFileUnsupported.ConflictingHeaders" Category="WopiCore">
         <Description>
           Tests the PutRelativeFile scenario where both a suggested name and a relative name are specified.
         </Description>
@@ -1722,7 +1727,7 @@
       <PrereqTest>UserCanWriteRelativePrereq</PrereqTest>
     </PrereqTests>
     <TestCases>
-      <TestCase Name="PutRelativeAndRenameFile.RenameShouldSucceed" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeAndRenameFile.RenameShouldSucceed" Category="WopiCore">
         <Description>
           Perform a PutRelativeFile operation, then rename and delete it. The rename operation should succeed.
         </Description>
@@ -1761,7 +1766,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeAndRenameFile.FileNameAfterRenameIsCorrectlyEncoded" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeAndRenameFile.FileNameAfterRenameIsCorrectlyEncoded" Category="WopiCore">
         <Description>
           Perform a PutRelativeFile operation, then rename it with a file name containing a special character and delete it.
           The rename operation should succeed and the server should return the name as a UTF-8 encoded string.
@@ -1801,7 +1806,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeAndRenameFile.RenamingALockedFileWithACorrectLockHeaderValueShouldSucceed" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeAndRenameFile.RenamingALockedFileWithACorrectLockHeaderValueShouldSucceed" Category="WopiCore">
         <Description>
           Perform a PutRelativeFile operation, then lock it and try to rename it with the correct lock ID. The rename operation should succeed.
         </Description>
@@ -1843,7 +1848,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeAndRenameFile.RenamingALockedFileWithAnIncorrectLockHeaderValueShouldReturnA409" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeAndRenameFile.RenamingALockedFileWithAnIncorrectLockHeaderValueShouldReturnA409" Category="WopiCore">
         <Description>
           Perform a PutRelativeFile operation, then lock it and try to rename it with an incorrect lock ID.
           The rename operation should fail with a Conflict - 409 status code.
@@ -1883,7 +1888,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeAndRenameFile.RenamingADeletedFileShouldReturnA404" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeAndRenameFile.RenamingADeletedFileShouldReturnA404" Category="WopiCore">
         <Description>
           Perform a PutRelativeFile operation, then delete it and try to rename it. The rename operation should fail with a 404 status code.
         </Description>
@@ -1919,7 +1924,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="PutRelativeAndRenameFile.RenameShouldNotChangeFileExtension" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="PutRelativeAndRenameFile.RenameShouldNotChangeFileExtension" Category="WopiCore">
         <Description>
           Perform a PutRelativeFile operation, then rename and delete it. The rename operation should not change the file extension of the file.
         </Description>
@@ -1981,7 +1986,7 @@
       <PrereqTest>UserCanCreateChildFilePrereq</PrereqTest>
     </PrereqTests>
     <TestCases>
-      <TestCase Name="CreateChildFileAndRenameFile.RenameShouldSucceed" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFileAndRenameFile.RenameShouldSucceed" Category="WopiCore">
         <Description>
           Create a file, then rename and delete it. The rename operation should succeed.
         </Description>
@@ -2027,7 +2032,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFileAndRenameFile.FileNameAfterRenameIsCorrectlyEncoded" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFileAndRenameFile.FileNameAfterRenameIsCorrectlyEncoded" Category="WopiCore">
         <Description>
           Create a file, then rename it with a file name containing a special character and delete it.
           The rename operation should succeed and the server should return the name as a UTF-8 encoded string.
@@ -2074,7 +2079,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFileAndRenameFile.RenamingALockedFileWithACorrectLockHeaderValueShouldSucceed" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFileAndRenameFile.RenamingALockedFileWithACorrectLockHeaderValueShouldSucceed" Category="WopiCore">
         <Description>
           Create a file, then lock it and try to rename it with the correct lock ID. The rename operation should succeed.
         </Description>
@@ -2123,7 +2128,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFileAndRenameFile.RenamingALockedFileWithAnIncorrectLockHeaderValueShouldReturnA409" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFileAndRenameFile.RenamingALockedFileWithAnIncorrectLockHeaderValueShouldReturnA409" Category="WopiCore">
         <Description>
           Create a file, then lock it and try to rename it with an incorrect lock ID.
           The rename operation should fail with a Conflict - 409 status code.
@@ -2170,7 +2175,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFileAndRenameFile.RenamingADeletedFileShouldReturnA404" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFileAndRenameFile.RenamingADeletedFileShouldReturnA404" Category="WopiCore">
         <Description>
           Create a file, then delete it and try to rename it. The rename operation should fail with a 404 status code.
         </Description>
@@ -2213,7 +2218,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFileAndRenameFile.RenameShouldNotChangeFileExtension" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFileAndRenameFile.RenameShouldNotChangeFileExtension" Category="WopiCore">
         <Description>
           Create a file, then rename and delete it. The rename operation should not change the file extension of the file.
         </Description>
@@ -2279,7 +2284,7 @@
     </PrereqTests>
     <TestCases>
       <!-- /files/GetEcosystem -->
-      <TestCase Name="files.GetEcosystem" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.GetEcosystem" Category="WopiCore">
         <Description>
           Tests that GetEcosystem returns a valid response.
         </Description>
@@ -2295,7 +2300,7 @@
       </TestCase>
 
       <!-- /ecosystem/CheckEcosystem -->
-      <TestCase Name="ecosystem.CheckEcosystem" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="ecosystem.CheckEcosystem" Category="WopiCore">
         <Description>
           Tests that CheckEcosystem returns a valid response.
         </Description>
@@ -2319,7 +2324,7 @@
       <!-- No tests -->
 
       <!-- /ecosystem/GetRootContainer -->
-      <TestCase Name="ecosystem.GetRootContainer" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="ecosystem.GetRootContainer" Category="WopiCore">
         <Description>
           Tests that GetRootContainer returns a valid response.
         </Description>
@@ -2340,7 +2345,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="ecosystem.GetRootContainerInvalidAccessToken" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="ecosystem.GetRootContainerInvalidAccessToken" Category="WopiCore">
         <Description>
           Tests that GetRootContainer denies requests with invalid access tokens.
         </Description>
@@ -2375,7 +2380,7 @@
     </PrereqTests>
     <TestCases>
       <!-- /containers/CheckContainerInfo -->
-      <TestCase Name="containers.CheckContainerInfo" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.CheckContainerInfo" Category="WopiCore">
         <Description>
           Tests that CheckContainerInfo returns a valid response.
         </Description>
@@ -2404,7 +2409,7 @@
 
       <!-- /containers/CreateChildContainer -->
       <!-- /containers/DeleteContainer -->
-      <TestCase Name="containers.CreateAndDeleteChildContainer" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.CreateAndDeleteChildContainer" Category="WopiCore">
         <Description>
           Tests creating a child container and deleting it.
         </Description>
@@ -2434,7 +2439,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="containers.CreateAndDeleteChildContainerDupe" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.CreateAndDeleteChildContainerDupe" Category="WopiCore">
         <Description>
           Tests that CreateChildContainer handles 'suggested mode' properly.
         </Description>
@@ -2471,7 +2476,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="containers.CreateAndDeleteChildContainerExactName" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.CreateAndDeleteChildContainerExactName" Category="WopiCore">
         <Description>
           Tests that CreateChildContainer handles 'specific mode' properly.
         </Description>
@@ -2501,7 +2506,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="containers.CreateAndDeleteChildContainerExactNameDupe" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.CreateAndDeleteChildContainerExactNameDupe" Category="WopiCore">
         <Description>
           Tests that CreateChildContainer handles conflicting container names when in 'specific mode' properly.
         </Description>
@@ -2541,7 +2546,7 @@
       </TestCase>
 
       <!-- /containers/GetEcosystem -->
-      <TestCase Name="containers.GetEcosystem" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.GetEcosystem" Category="WopiCore">
         <Description>/files/EnumerateAncestors then /containers/GetEcosystem on each element</Description>
         <Requests>
           <EnumerateAncestors>
@@ -2560,7 +2565,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="containers.LicensingPropertiesOnChildFolderMatchWithParentFolder" Document="WordBlankDocument" Category="OfficeNativeClient">
+      <TestCase Name="containers.LicensingPropertiesOnChildFolderMatchWithParentFolder" Category="OfficeNativeClient">
         <Description>
           Verify that some CheckContainerInfo user properties match between a child container and its parent.
         </Description>
@@ -2615,7 +2620,7 @@
     </PrereqTests>
     <TestCases>
       <!-- /containers/RenameContainer -->
-      <TestCase Name="containers.CreateAndRenameChildContainer" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.CreateAndRenameChildContainer" Category="WopiCore">
         <Description>
           Tests that RenameContainer is handled properly.
         </Description>
@@ -2652,7 +2657,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="containers.CreateAndRenameChildContainerAndVerifyReturnedContainerNameIsCorrectlyEncoded" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.CreateAndRenameChildContainerAndVerifyReturnedContainerNameIsCorrectlyEncoded" Category="WopiCore">
         <Description>
           Tests the Containers.RenameChildContainer scenario where a Relative name is specified. Expect the host to rename
           the container with the exact name as specified. Also ensure that the host returns a UTF-8 encoded version of the ContainerName.
@@ -2701,7 +2706,7 @@
     </PrereqTests>
     <TestCases>
       <!-- /files/EnumerateAncestors -->
-      <TestCase Name="files.EnumerateAncestors" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.EnumerateAncestors" Category="WopiCore">
         <Description>just EnumerateAncestors</Description>
         <Requests>
           <EnumerateAncestors>
@@ -2716,7 +2721,7 @@
       </TestCase>
 
       <!-- /containers/EnumerateChildren -->
-      <TestCase Name="containers.EnumerateChildren" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.EnumerateChildren" Category="WopiCore">
         <Description>/files/EnumerateAncestors then /containers/EnumerateChildren on the parent folder</Description>
         <Requests>
           <EnumerateAncestors>
@@ -2737,7 +2742,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="containers.EnumerateChildrenOnRoot" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.EnumerateChildrenOnRoot" Category="WopiCore">
         <Description>/files/EnumerateAncestors then /containers/EnumerateChildren on the root folder</Description>
         <Requests>
           <EnumerateAncestors>
@@ -2751,7 +2756,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="containers.EnumerateChildrenWithOneFilter" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.EnumerateChildrenWithOneFilter" Category="WopiCore">
         <Description>/files/EnumerateAncestors then /containers/EnumerateChildren on the parent folder with a file extension filter</Description>
         <Requests>
           <EnumerateAncestors>
@@ -2772,7 +2777,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="containers.EnumerateChildrenWithMultipleFilters" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.EnumerateChildrenWithMultipleFilters" Category="WopiCore">
         <Description>/files/EnumerateAncestors then /containers/EnumerateChildren on the parent folder with multiple file extensions filtered</Description>
         <Requests>
           <EnumerateAncestors>
@@ -2794,7 +2799,7 @@
       </TestCase>
 
       <!-- /containers/EnumerateAncestors -->
-      <TestCase Name="containers.EnumerateAncestorsOnRoot" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.EnumerateAncestorsOnRoot" Category="WopiCore">
         <Description>/files/EnumerateAncestors then /containers/EnumerateAncestors on a container which is a root container</Description>
         <Requests>
           <EnumerateAncestors>
@@ -2811,7 +2816,7 @@
       </TestCase>
 
       <!-- /containers/EnumerateAncestors -->
-      <TestCase Name="containers.EnumerateAncestorsOnChildren" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.EnumerateAncestorsOnChildren" Category="WopiCore">
         <Description>/files/EnumerateAncestors then /containers/EnumerateAncestors on a container which is not a root container</Description>
         <Requests>
           <EnumerateAncestors>
@@ -2858,7 +2863,7 @@
     <TestCases>
       <!-- /containers/CreateChildFile -->
       <!-- /files/DeleteFile -->
-      <TestCase Name="CreateChildFileAndDelete" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFileAndDelete" Category="WopiCore">
         <Description>
           /files/EnumerateAncestors then go to a container that has UserCanCreateChildFile=true.
           create a file.  delete it.
@@ -2886,7 +2891,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="CreateChildFile.SuggestedName" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFile.SuggestedName" Category="WopiCore">
         <Description>
           Tests the Containers.CreateChildFile scenario where a suggested name is specified.
         </Description>
@@ -2923,7 +2928,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFile.SuggestedNameConflict" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFile.SuggestedNameConflict" Category="WopiCore">
         <Description>
           Tests the Containers.CreateChildFile scenario where a suggested name is specified but
           a file with the target name already exists. Expect the request to succeed with the host
@@ -2977,7 +2982,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFile.RelativeName" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFile.RelativeName" Category="WopiCore">
         <Description>
           Tests the Containers.CreateChildFile scenario where a Relative name is specified. Expect the host to create
           a new file with the exact name as specified.
@@ -3015,7 +3020,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFile.RelativeNameOverwriteTrueNoEffect" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFile.RelativeNameOverwriteTrueNoEffect" Category="WopiCore">
         <Description>
           Tests the Containers.CreateChildFile scenario where a Relative name is specified and OverwriteRelative
           is set to true. Since no file with target name exists in this scenario, the header should have
@@ -3054,7 +3059,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFile.RelativeNameOverwriteFalseNoEffect" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFile.RelativeNameOverwriteFalseNoEffect" Category="WopiCore">
         <Description>
           Tests the Containers.CreateChildFile scenario where a Relative name is specified and OverwriteRelative
           is set to false. Since no file with target name exists in this scenario, the header should have
@@ -3093,7 +3098,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFile.RelativeNameConflictNoOverwrite" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFile.RelativeNameConflictNoOverwrite" Category="WopiCore">
         <Description>
           Tests the Containers.CreateChildFile scenario where a Relative name is specified and OverwriteRelative
           is not specified. Since a file with target name exists in this scenario, expect the host to
@@ -3137,7 +3142,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFile.RelativeNameConflictOverwriteFalse" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFile.RelativeNameConflictOverwriteFalse" Category="WopiCore">
         <Description>
           Tests the Containers.CreateChildFile scenario where a Relative name is specified and OverwriteRelative
           is set to false. Since a file with target name exists in this scenario, expect the host to
@@ -3181,7 +3186,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFile.RelativeNameConflictOverwriteTrue" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFile.RelativeNameConflictOverwriteTrue" Category="WopiCore">
         <Description>
           Tests the Containers.CreateChildFile scenario where a Relative name is specified and OverwriteRelative
           is set to true. Since a file with target name exists in this scenario, expect the host to
@@ -3239,7 +3244,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFile.ConflictingHeaders" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFile.ConflictingHeaders" Category="WopiCore">
         <Description>
           Tests the Containers.CreateChildFile scenario where both a suggested name and a relative name are specified.
           Expect the host to fail the request as bad request.
@@ -3266,7 +3271,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="CreateChildFile.RelativeNameConflictOverwriteTrueLocked" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFile.RelativeNameConflictOverwriteTrueLocked" Category="WopiCore">
         <Description>
           Tests the Containers.CreateChildFile scenario where a relative name is specified along with OverwriteRelative
           set to true, but a file with the same target name already exists and is locked. Expect the host
@@ -3312,7 +3317,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFile.FileNameReturnedIsCorrectlyEncoded" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFile.FileNameReturnedIsCorrectlyEncoded" Category="WopiCore">
         <Description>
           Tests the Containers.CreateChildFile scenario where a Relative name is specified. Expect the host to create
           a new file with the exact name as specified. Also ensure that the host returns a UTF-8 encoded version of the FileName.
@@ -3347,7 +3352,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFile.FileNameLongerThan512Characters" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="CreateChildFile.FileNameLongerThan512Characters" Category="WopiCore">
         <Description>
           Tests the Containers.CreateChildFile scenario where a file name is longer than 512 characters, then the host should return a 400 or 200.
         </Description>
@@ -3382,7 +3387,7 @@
         </CleanupRequests>
       </TestCase>
 
-      <TestCase Name="CreateChildFile.LicensingPropertiesOnChildFileMatchWithParentFolder" Document="WordBlankDocument" Category="OfficeNativeClient">
+      <TestCase Name="CreateChildFile.LicensingPropertiesOnChildFileMatchWithParentFolder" Category="OfficeNativeClient">
         <Description>
           Verify that some CheckContainerInfo and CheckFileInfo user properties match between a child file and its parent container.
         </Description>
@@ -3437,7 +3442,7 @@
       <PrereqTest>FileUrlUsagePrereq</PrereqTest>
     </PrereqTests>
     <TestCases>
-      <TestCase Name="GetFromFileUrl" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="GetFromFileUrl" Category="WopiCore">
         <Description>
           Use FileUrl if supported by host to directly retrieve the contents of a file instead of using GetFile.
         </Description>
@@ -3469,7 +3474,7 @@
       <PrereqTest>ShareUrlTypeReadOnlyForFilePrereq</PrereqTest>
     </PrereqTests>
     <TestCases>
-      <TestCase Name="files.GetShareUrlForReadOnlyUrlType" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.GetShareUrlForReadOnlyUrlType" Category="WopiCore">
         <Description>
           Tests the GetShareUrl operation for a file where the requested share url type is "ReadOnly".
         </Description>
@@ -3493,7 +3498,7 @@
       <PrereqTest>ShareUrlTypeReadWriteForFilePrereq</PrereqTest>
     </PrereqTests>
     <TestCases>
-      <TestCase Name="files.GetShareUrlForReadWriteUrlType" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.GetShareUrlForReadWriteUrlType" Category="WopiCore">
         <Description>
           Tests the GetShareUrl operation for a file where the requested share url type is "ReadWrite".
         </Description>
@@ -3517,7 +3522,7 @@
       <PrereqTest>SupportedShareUrlTypesForFilePrereq</PrereqTest>
     </PrereqTests>
     <TestCases>
-      <TestCase Name="files.GetShareUrlForUnknownUrlType" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.GetShareUrlForUnknownUrlType" Category="WopiCore">
         <Description>
           Tests the GetShareUrl operation for a file where the requested share url type is unknown.
         </Description>
@@ -3540,7 +3545,7 @@
       <PrereqTest>ShareUrlTypeReadOnlyForContainerPrereq</PrereqTest>
     </PrereqTests>
     <TestCases>
-      <TestCase Name="containers.GetShareUrlForReadOnlyUrlType" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.GetShareUrlForReadOnlyUrlType" Category="WopiCore">
         <Description>
           Tests the GetShareUrl operation for a container where the requested share url type is "ReadOnly".
         </Description>
@@ -3571,7 +3576,7 @@
       <PrereqTest>ShareUrlTypeReadWriteForContainerPrereq</PrereqTest>
     </PrereqTests>
     <TestCases>
-      <TestCase Name="containers.GetShareUrlForReadWriteUrlType" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.GetShareUrlForReadWriteUrlType" Category="WopiCore">
         <Description>
           Tests the GetShareUrl operation for a container where the requested share url type is "ReadWrite".
         </Description>
@@ -3602,7 +3607,7 @@
       <PrereqTest>SupportedShareUrlTypesForContainerPrereq</PrereqTest>
     </PrereqTests>
     <TestCases>
-      <TestCase Name="containers.GetShareUrlForUnknownUrlType" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="containers.GetShareUrlForUnknownUrlType" Category="WopiCore">
         <Description>
           Tests the GetShareUrl operation for a container where the requested share url type is unknown.
         </Description>
@@ -3633,7 +3638,7 @@
     </PrereqTests>
     <TestCases>
       <!-- /files/AddActivities -->
-      <TestCase Name="files.AddActivitiesSingleMinimalComment" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesSingleMinimalComment" Category="WopiCore">
         <Description>one comment, minimal properties</Description>
         <Requests>
           <AddActivities>
@@ -3667,7 +3672,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesSingleFullComment" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesSingleFullComment" Category="WopiCore">
         <Description>one comment with all data properties set</Description>
         <Requests>
           <AddActivities>
@@ -3704,7 +3709,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesAllCapsID" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesAllCapsID" Category="WopiCore">
         <Description>one comment with all-caps ID GUID</Description>
         <Requests>
           <AddActivities>
@@ -3738,7 +3743,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesMaxLengthContentID" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesMaxLengthContentID" Category="WopiCore">
         <Description>one comment with max-length ContentID</Description>
         <Requests>
           <AddActivities>
@@ -3772,7 +3777,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesMaxLengthNavigationId" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesMaxLengthNavigationId" Category="WopiCore">
         <Description>one comment with max-length NavigationId</Description>
         <Requests>
           <AddActivities>
@@ -3807,7 +3812,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesCommentUpdate" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesCommentUpdate" Category="WopiCore">
         <Description>one comment with ContentAction=update</Description>
         <Requests>
           <AddActivities>
@@ -3841,7 +3846,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesCommentDelete" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesCommentDelete" Category="WopiCore">
         <Description>one comment with ContentAction=delete</Description>
         <Requests>
           <AddActivities>
@@ -3875,7 +3880,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesWithBonusToplevelProperty" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesWithBonusToplevelProperty" Category="WopiCore">
         <Description>one comment with bogus additional toplevel property</Description>
         <Requests>
           <AddActivities>
@@ -3910,7 +3915,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesWithBonusDataProperty" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesWithBonusDataProperty" Category="WopiCore">
         <Description>one comment with bogus additional data property</Description>
         <Requests>
           <AddActivities>
@@ -3945,7 +3950,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesCommentAndPerson" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesCommentAndPerson" Category="WopiCore">
         <Description>one comment, one person</Description>
         <Requests>
           <AddActivities>
@@ -3987,7 +3992,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesCommentWithThreePeople" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesCommentWithThreePeople" Category="WopiCore">
         <Description>one comment, three people</Description>
         <Requests>
           <AddActivities>
@@ -4042,7 +4047,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesCommentWithPersonBonusProperty" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesCommentWithPersonBonusProperty" Category="WopiCore">
         <Description>one comment, one person with bogus additional property</Description>
         <Requests>
           <AddActivities>
@@ -4085,7 +4090,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesCommentWithNonWopiPerson" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesCommentWithNonWopiPerson" Category="WopiCore">
         <Description>one comment, one person with non-wopi provider and ID</Description>
         <Requests>
           <AddActivities>
@@ -4127,7 +4132,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesUnknownActivityType" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesUnknownActivityType" Category="WopiCore">
         <Description>one activity with bogus type</Description>
         <Requests>
           <AddActivities>
@@ -4156,7 +4161,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesUnknownNoDataActivity" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesUnknownNoDataActivity" Category="WopiCore">
         <Description>one activity with bogus type and no data</Description>
         <Requests>
           <AddActivities>
@@ -4186,7 +4191,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesTwoActivitiesOneUnknown" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesTwoActivitiesOneUnknown" Category="WopiCore">
         <Description>one comment and one activity with bogus type</Description>
         <Requests>
           <AddActivities>
@@ -4245,7 +4250,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="files.AddActivitiesThreeComments" Document="WordBlankDocument" Category="WopiCore">
+      <TestCase Name="files.AddActivitiesThreeComments" Category="WopiCore">
         <Description>three comments</Description>
         <Requests>
           <AddActivities>
@@ -4325,7 +4330,7 @@
       <PrereqTest>WopiValidatorPrereq</PrereqTest>
     </PrereqTests>
     <TestCases>
-      <TestCase Name="ProofKeys.CurrentValid.OldValid" Document="WordBlankDocument" Category="OfficeOnline">
+      <TestCase Name="ProofKeys.CurrentValid.OldValid" Category="OfficeOnline">
         <Description>
           Tests that hosts accept requests where the X-WOPI-Proof value is correctly signed with the current proof key,
           and the X-WOPI-ProofOld value is signed with the old proof key.
@@ -4335,7 +4340,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="ProofKeys.CurrentValid.OldInvalid" Document="WordBlankDocument" Category="OfficeOnline">
+      <TestCase Name="ProofKeys.CurrentValid.OldInvalid" Category="OfficeOnline">
         <Description>
           Tests that hosts accept requests where the X-WOPI-Proof value is correctly signed with the current proof key,
           but the X-WOPI-ProofOld value is invalid. This scenario is unusual and should not happen in a production
@@ -4351,7 +4356,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="ProofKeys.CurrentInvalid.OldValidSignedWithCurrentKey" Document="WordBlankDocument" Category="OfficeOnline">
+      <TestCase Name="ProofKeys.CurrentInvalid.OldValidSignedWithCurrentKey" Category="OfficeOnline">
         <Description>
           Tests that hosts accept requests where the X-WOPI-Proof value is invalid but the X-WOPI-ProofOld value is
           signed with current public key. This can happen when a WOPI client such as Office Online has rotated proof keys
@@ -4366,7 +4371,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="ProofKeys.CurrentValidSignedWithOldKey.OldInvalid" Document="WordBlankDocument" Category="OfficeOnline">
+      <TestCase Name="ProofKeys.CurrentValidSignedWithOldKey.OldInvalid" Category="OfficeOnline">
         <Description>
           Tests that hosts accept requests where the X-WOPI-ProofOld value is invalid but the X-WOPI-Proof value is
           signed with old public key. This can happen when a WOPI client has rotated proof keys, the host has re-run
@@ -4382,7 +4387,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="ProofKeys.CurrentInvalid.OldValidSignedWithOldKey" Document="WordBlankDocument" Category="OfficeOnline">
+      <TestCase Name="ProofKeys.CurrentInvalid.OldValidSignedWithOldKey" Category="OfficeOnline">
         <Description>
           Tests that hosts reject requests where the X-WOPI-Proof value is invalid, and the X-WOPI-ProofOld value
           is signed with the old public key. This scenario is unusual and should not happen in a production
@@ -4400,7 +4405,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="ProofKeys.CurrentInvalid.OldInvalid" Document="WordBlankDocument" Category="OfficeOnline">
+      <TestCase Name="ProofKeys.CurrentInvalid.OldInvalid" Category="OfficeOnline">
         <Description>
           Tests that hosts reject requests with invalid current and old proof keys.
         </Description>
@@ -4416,7 +4421,7 @@
         </Requests>
       </TestCase>
 
-      <TestCase Name="ProofKeys.TimestampOlderThan20Min" Document="WordBlankDocument" Category="OfficeOnline">
+      <TestCase Name="ProofKeys.TimestampOlderThan20Min" Category="OfficeOnline">
         <Description>
           Tests that hosts reject requests with an X-WOPI-Timestamp value that represents a time more than 20 minutes old.
         </Description>

--- a/TestCases.xsd
+++ b/TestCases.xsd
@@ -128,7 +128,7 @@
           <xs:complexType>
             <xs:complexContent>
               <xs:extension base="ValidatorBaseType">
-                <xs:attribute name="ExpectedDocumentId" type="xs:string" use="optional" />
+                <xs:attribute name="ExpectedResourceId" type="xs:string" use="optional" />
                 <xs:attribute name="ExpectedBodyContent" type="xs:string" use="optional" />
               </xs:extension>
             </xs:complexContent>

--- a/TestCases.xsd
+++ b/TestCases.xsd
@@ -503,13 +503,10 @@
       </xs:element>
     </xs:sequence>
     <xs:attribute name="Name" type="xs:string" use="required" />
-    <xs:attribute name="Document" type="xs:string" use="required" />
     <xs:attribute name="Category" type="xs:string" use="optional" />
     <xs:attribute name="UiScreenshot" type="xs:string" use="optional" />
     <xs:attribute name="DocumentationLink" type="xs:string" use="optional" />
     <xs:attribute name="FailMessage" type="xs:string" use="optional" />
-    <xs:attribute name="UploadDocumentOnSetup" type="xs:boolean" use="optional" default="false" />
-    <xs:attribute name="DeleteDocumentOnTeardown" type="xs:boolean" use="optional" default="false" />
   </xs:complexType>
 
   <!-- Concrete definition of the entire WopiValidation -->

--- a/src/WopiValidator.Core/Factories/TestCaseFactory.cs
+++ b/src/WopiValidator.Core/Factories/TestCaseFactory.cs
@@ -53,14 +53,10 @@ namespace Microsoft.Office.WopiValidator.Core.Factories
 		{
 			string category = (string)definition.Attribute("Category");
 			string name = (string)definition.Attribute("Name");
-			string resourceId = (string)definition.Attribute("Document");
 			string description = (string)definition.Element("Description");
 			string uiScreenshot = (string)definition.Attribute("UiScreenshot");
 			string documentationLink = (string)definition.Attribute("DocumentationLink");
 			string failMessage = (string)definition.Attribute("FailMessage");
-
-			bool uploadDocumentOnSetup = (bool?)definition.Attribute("UploadDocumentOnSetup") ?? true;
-			bool deleteDocumentOnTeardown = (bool?)definition.Attribute("DeleteDocumentOnTeardown") ?? true;
 
 			XElement requestsDefinition = definition.Element("Requests");
 			IEnumerable<IRequest> requests = RequestFactory.GetRequests(requestsDefinition);
@@ -70,18 +66,16 @@ namespace Microsoft.Office.WopiValidator.Core.Factories
 			if (cleanupRequestsDefinition != null)
 				cleanupRequests = RequestFactory.GetRequests(cleanupRequestsDefinition);
 
-			ITestCase testCase = new TestCase(resourceId,
-				requests,
+			ITestCase testCase = new TestCase(requests,
 				cleanupRequests,
 				name,
 				CondenseMultiLineString(description),
-				uploadDocumentOnSetup,
-				deleteDocumentOnTeardown,
-				category);
-
-			testCase.UiScreenShot = uiScreenshot;
-			testCase.DocumentationLink = documentationLink;
-			testCase.FailMessage = failMessage;
+				category)
+			{
+				UiScreenShot = uiScreenshot,
+				DocumentationLink = documentationLink,
+				FailMessage = failMessage
+			};
 
 			return testCase;
 		}

--- a/src/WopiValidator.Core/Factories/ValidatorFactory.cs
+++ b/src/WopiValidator.Core/Factories/ValidatorFactory.cs
@@ -62,9 +62,9 @@ namespace Microsoft.Office.WopiValidator.Core.Factories
 		/// </summary>
 		private static IValidator GetResponseContentValidator(XElement definition)
 		{
-			string documentId = (string)definition.Attribute("ExpectedDocumentId");
+			string resourceId = (string)definition.Attribute("ExpectedResourceId");
 			string expectedBodyContent = (string)definition.Attribute("ExpectedBodyContent");
-			return new ResponseContentValidator(documentId, expectedBodyContent);
+			return new ResponseContentValidator(resourceId, expectedBodyContent);
 		}
 
 		/// <summary>

--- a/src/WopiValidator.Core/ITestCase.cs
+++ b/src/WopiValidator.Core/ITestCase.cs
@@ -15,17 +15,11 @@ namespace Microsoft.Office.WopiValidator.Core
 
 		IEnumerable<IRequest> CleanupRequests { get; }
 
-		string ResourceId { get; }
-
 		string UiScreenShot { get; set; }
 
 		string DocumentationLink { get; set; }
 
 		string FailMessage { get; set; }
-
-		bool UploadDocumentOnSetup { get; }
-
-		bool DeleteDocumentOnTearDown { get; }
 
 		string Category { get; }
 	}

--- a/src/WopiValidator.Core/TestCase.cs
+++ b/src/WopiValidator.Core/TestCase.cs
@@ -13,18 +13,12 @@ namespace Microsoft.Office.WopiValidator.Core
 	class TestCase : ITestCase
 	{
 		public TestCase(
-			string resourceId,
 			IEnumerable<IRequest> requests,
 			IEnumerable<IRequest> cleanupRequests,
 			string name,
 			string description,
-			bool uploadDocumentOnSetup,
-			bool deleteDocumentOnTearDown,
 			string category)
 		{
-			DeleteDocumentOnTearDown = deleteDocumentOnTearDown;
-			UploadDocumentOnSetup = uploadDocumentOnSetup;
-
 			if (requests == null)
 				throw new ArgumentNullException("requests");
 			Requests = requests.ToArray();
@@ -34,10 +28,6 @@ namespace Microsoft.Office.WopiValidator.Core
 			if (cleanupRequests == null)
 				cleanupRequests = Enumerable.Empty<IRequest>();
 			CleanupRequests = cleanupRequests.ToArray();
-
-			if (string.IsNullOrEmpty(resourceId))
-				throw new ArgumentException("ResourceId cannot be empty.", "resourceId");
-			ResourceId = resourceId;
 
 			if (string.IsNullOrEmpty(name))
 				throw new ArgumentException("Name cannot be empty.", "name");
@@ -54,12 +44,9 @@ namespace Microsoft.Office.WopiValidator.Core
 		public IEnumerable<IRequest> CleanupRequests { get; private set; }
 		public string Name { get; private set; }
 		public string Description { get; private set; }
-		public string ResourceId { get; private set; }
 		public string UiScreenShot { get; set; }
 		public string DocumentationLink { get; set; }
 		public string FailMessage {get; set; }
-		public bool UploadDocumentOnSetup { get; private set; }
-		public bool DeleteDocumentOnTearDown { get; private set; }
 		public string Category { get; private set; }
 	}
 }


### PR DESCRIPTION
We use the 'resource' term everywhere else.