### PR TITLE
Allow files.PutFileReturnsDifferentVersion to pass when version is based on file content

### DIFF
--- a/TestCases.xml
+++ b/TestCases.xml
@@ -1124,18 +1124,10 @@
         </Description>
         <Requests>
           <Lock Lock="LockString" />
-          <CheckFileInfo>
-            <SaveState>
-              <State Name="OriginalVersion" Source="Version" />
-            </SaveState>
-          </CheckFileInfo>
           <PutFile Lock="LockString" ResourceId="WordSimpleDocument">
             <SaveState>
               <State Name="SecondVersion" Source="X-WOPI-ItemVersion" SourceType="Header" />
             </SaveState>
-            <Validators>
-              <ResponseHeaderValidator Header="X-WOPI-ItemVersion" ExpectedStateKey="OriginalVersion" ShouldMatch="false" />
-            </Validators>
           </PutFile>
           <PutFile Lock="LockString" ResourceId="WordComplexDocument">
             <Validators>


### PR DESCRIPTION
It feels like the validator is dependent on the order the tests are run. If we use the SHA256 (or any file content based method) as a X-WOPI-ItemVersion and run each test in isolation files.PutFileReturnsDifferentVersion passes fine. It doesn't pass when you run all the tests together because a previous test (files.PutFileReturnsVersion) runs and sets the file to  WordSimpleDocument. Then the first request in files.PutFileReturnsDifferentVersion also puts the same file (WordSimpleDocument) but then checks that the X-WOPI-ItemVersion has changed. Since it's the same file the hash doesn't change and the test is marked a failure.

The proposed fix is to not do the first check (and thus the CheckFileInfo call doesn't need to be made) and simply rely on the second PUT request to check if the requirements of the tests are accounted for. 