### PR TITLE
Update dotnet Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ solution: WopiValidator.sln
 sudo: required
 dist: xenial
 script:
-  - dotnet build -c Release -f netcoreapp2.0
-  - dotnet test ./test/WopiValidator.Core.Tests/WopiValidator.Core.Tests.csproj -c Release -f netcoreapp2.0
+  - dotnet build -c Release -f net6.0
+  - dotnet test ./test/WopiValidator.Core.Tests/WopiValidator.Core.Tests.csproj -c Release -f net6.0

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/src/WopiValidator/bin/Debug/netcoreapp2.0/Microsoft.Office.WopiValidator.dll",
+      "program": "${workspaceFolder}/src/WopiValidator/bin/Debug/net6.0/Microsoft.Office.WopiValidator.dll",
       "args": [
         "-w",
         "http://localhost:5000/wopi/files/1",
@@ -31,7 +31,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/src/WopiValidator/bin/Debug/netcoreapp2.0/Microsoft.Office.WopiValidator.dll",
+      "program": "${workspaceFolder}/src/WopiValidator/bin/Debug/net6.0/Microsoft.Office.WopiValidator.dll",
       "args": [
         "-w",
         "http://localhost:5000/wopi/files/1",
@@ -54,7 +54,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/src/WopiValidator/bin/Debug/netcoreapp2.0/Microsoft.Office.WopiValidator.dll",
+      "program": "${workspaceFolder}/src/WopiValidator/bin/Debug/net6.0/Microsoft.Office.WopiValidator.dll",
       "args": [],
       "cwd": "${workspaceFolder}/",
       // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 This project contains the core logic of the [WOPI validator](https://wopi.readthedocs.io/en/latest/build_test_ship/validator.html)
 as well as a command-line interface to it.
 
+## Notes
+
+In the examples below `<id>` must be an id that refers to a file named "test.wopitest". The file must exist.
+
 ## Quick start using Docker
 
 You can quickly run the validator using Docker. First, pull the Docker image:
@@ -17,7 +21,7 @@ You can quickly run the validator using Docker. First, pull the Docker image:
 
 Then run the validator using a command like the following:
 
-`docker run -it --rm tylerbutler/wopi-validator -- -w http://localhost:5000/wopi/files/1 -t myToken -l 0 -s`
+`docker run -it --rm tylerbutler/wopi-validator -- -w http://localhost:5000/wopi/files/<id> -t myToken -l 0 -s`
 
 Note the `--`; parameters after the `--` will be passed to the validator itself
 
@@ -97,7 +101,7 @@ See [the quick start](#quick-start-using-docker).
 After building the projects as described above, you can run the resulting `Microsoft.Office.WopiValidator.dll`
 using the `dotnet` command. For example:
 
-`dotnet Microsoft.Office.WopiValidator.dll --token MyAccessToken --token_ttl 0 --wopisrc http://localhost:5000/wopi/files/1 --testcategory OfficeOnline --ignore-skipped`
+`dotnet Microsoft.Office.WopiValidator.dll --token MyAccessToken --token_ttl 0 --wopisrc http://localhost:5000/wopi/files/<id> --testcategory OfficeOnline --ignore-skipped`
 
 Note: the Microsoft.Office.WopiValidator.dll file can be found in `src\WopiValidator\bin\Release\net6.0\`.
 
@@ -107,7 +111,7 @@ You can also use the `dotnet run` command, passing the path to the `WopiValidato
 option. Arguments to the validator itself can be passed in by separating them from the `dotnet run` arguments with
 a `--`. For example:
 
-`dotnet run --project ./src/WopiValidator/WopiValidator.csproj --framework net6.0 -- -t MyAccessToken -l 0 -w http://localhost:5000/wopi/files/1 -e OfficeOnline -s`
+`dotnet run --project ./src/WopiValidator/WopiValidator.csproj --framework net6.0 -- -t MyAccessToken -l 0 -w http://localhost:5000/wopi/files/<id> -e OfficeOnline -s`
 
 ### Option 4: self-contained package
 
@@ -115,7 +119,7 @@ Another option is to build a self-contained package for your OS (see above) and 
 file, which be called `Microsoft.Office.Validator.exe` on Windows and `Microsoft.Office.Validator` on Linux and macOS.
 Arguments to the validator can be passed in directly. For example:
 
-`Microsoft.Office.Validator.exe -t MyAccessToken -l 0 -w http://localhost:5000/wopi/files/1 -e OfficeOnline -s`
+`Microsoft.Office.Validator.exe -t MyAccessToken -l 0 -w http://localhost:5000/wopi/files/<id> -e OfficeOnline -s`
 
 ### Full usage options
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The project can be built in Visual Studio 2017, Visual Studio Code, or using `do
 
 `dotnet build -c Release`
 
-The resulting build will be output to `src\WopiValidator\bin\Release\netcoreapp2.0\`. Omit the `-c Release`
+The resulting build will be output to `src\WopiValidator\bin\Release\net6.0\`. Omit the `-c Release`
 portion if you want to build the debug version instead.
 
 ### Building a self-contained package
@@ -38,15 +38,15 @@ portion if you want to build the debug version instead.
 To build a [self-contained package][1] for Linux or macOS, use the `dotnet publish` command:
 
 ```text
-dotnet publish -c Release -f netcoreapp2.0 -r linux-x64
-dotnet publish -c Release -f netcoreapp2.0 -r osx-x64
-dotnet publish -c Release -f netcoreapp2.0 -r win-x64
+dotnet publish -c Release -f net6.0 -r linux-x64
+dotnet publish -c Release -f net6.0 -r osx-x64
+dotnet publish -c Release -f net6.0 -r win-x64
 ```
 
 Note: you may see an error on build like this:
 
 ```text
-error MSB3030: Could not copy the file "obj\Release\netcoreapp2.0\win-x64\Microsoft.Office.WopiValidator.dll"
+error MSB3030: Could not copy the file "obj\Release\net6.0\win-x64\Microsoft.Office.WopiValidator.dll"
 because it was not found.
 ```
 
@@ -54,7 +54,7 @@ If you see this error, you should re-build the app using the same `-r` option us
 if you were trying to package the Linux self-contained package, first build the app using
 `dotnet build -c Release -r linux-x64`, then publish it using `dotnet publish -c Release -r linux-x64`.
 
-The output will be placed in `src/WopiValidator/bin/Release/netcoreapp2.0/linux-x64/publish` (replace `linux-x64`
+The output will be placed in `src/WopiValidator/bin/Release/net6.0/linux-x64/publish` (replace `linux-x64`
 with other platforms as needed).
 
 [1]: https://docs.microsoft.com/en-us/dotnet/core/deploying/deploy-with-cli
@@ -99,7 +99,7 @@ using the `dotnet` command. For example:
 
 `dotnet Microsoft.Office.WopiValidator.dll --token MyAccessToken --token_ttl 0 --wopisrc http://localhost:5000/wopi/files/1 --testcategory OfficeOnline --ignore-skipped`
 
-Note: the Microsoft.Office.WopiValidator.dll file can be found in `src\WopiValidator\bin\Release\netcoreapp2.0\`.
+Note: the Microsoft.Office.WopiValidator.dll file can be found in `src\WopiValidator\bin\Release\net6.0\`.
 
 ### Option 3: `dotnet run --project`
 
@@ -107,7 +107,7 @@ You can also use the `dotnet run` command, passing the path to the `WopiValidato
 option. Arguments to the validator itself can be passed in by separating them from the `dotnet run` arguments with
 a `--`. For example:
 
-`dotnet run --project ./src/WopiValidator/WopiValidator.csproj --framework netcoreapp2.0 -- -t MyAccessToken -l 0 -w http://localhost:5000/wopi/files/1 -e OfficeOnline -s`
+`dotnet run --project ./src/WopiValidator/WopiValidator.csproj --framework net6.0 -- -t MyAccessToken -l 0 -w http://localhost:5000/wopi/files/1 -e OfficeOnline -s`
 
 ### Option 4: self-contained package
 

--- a/src/WopiValidator.Core/ProofKeyHelper.cs
+++ b/src/WopiValidator.Core/ProofKeyHelper.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Office.WopiValidator.Core
 		{
 			ProofKeyOutput output = GetProofData(proofData);
 
-			using (SHA256CryptoServiceProvider hashAlg = new SHA256CryptoServiceProvider())
+			using (SHA256 hashAlg = SHA256.Create())
 			{
 				byte[] signedProofBytes = rsaAlg.SignData(output.PreSigningBytes, hashAlg);
 				output.SignedBase64ProofKey = Convert.ToBase64String(signedProofBytes);

--- a/src/WopiValidator.Core/Requests/RenameContainerRequest.cs
+++ b/src/WopiValidator.Core/Requests/RenameContainerRequest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 		{
 			return new Dictionary<string, string>
 				{
-					{ Constants.Headers.RequestedName, Encoding.UTF8.GetString(Encoding.UTF7.GetBytes(RequestedName)) },
+					{ Constants.Headers.RequestedName, Encoding.UTF8.GetString(Encoding.UTF8.GetBytes(RequestedName)) },
 				};
 		}
 	}

--- a/src/WopiValidator.Core/Requests/RenameFileRequest.cs
+++ b/src/WopiValidator.Core/Requests/RenameFileRequest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 		{
 			return new Dictionary<string, string>
 				{
-					{ Constants.Headers.RequestedName, Encoding.UTF8.GetString(Encoding.UTF7.GetBytes(RequestedName)) },
+					{ Constants.Headers.RequestedName, Encoding.UTF8.GetString(Encoding.UTF8.GetBytes(RequestedName)) },
 					{ Constants.Headers.Lock, LockString }
 				};
 		}

--- a/src/WopiValidator.Core/UrlHelper.cs
+++ b/src/WopiValidator.Core/UrlHelper.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Office.WopiValidator.Core
 				return inputData;
 			}
 
-			return Uri.UnescapeDataString(HttpUtility.UrlEncode(inputData, Encoding.UTF7));
+			return Uri.UnescapeDataString(HttpUtility.UrlEncode(inputData, Encoding.UTF8));
 		}
 
 		private static void UrlEncodeUnicodeChar(

--- a/src/WopiValidator.Core/WopiValidator.Core.csproj
+++ b/src/WopiValidator.Core/WopiValidator.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.0;netcoreapp2.2;net45</TargetFrameworks>
+    <TargetFrameworks>net6.0;</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../WopiValidatorSigningKey.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -23,16 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NJsonSchema" Version="6.8.6197.43075" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <Reference Include="System" />
-    <Reference Include="System.Collections.Concurrent" />
-    <Reference Include="System.Security" />
-    <Reference Include="System.Web" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WopiValidator/WopiValidator.csproj
+++ b/src/WopiValidator/WopiValidator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.2;net45</TargetFrameworks>
+    <TargetFrameworks>net6.0;</TargetFrameworks>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../WopiValidatorSigningKey.snk</AssemblyOriginatorKeyFile>

--- a/test/WopiValidator.Core.Tests/WopiValidator.Core.Tests.csproj
+++ b/test/WopiValidator.Core.Tests/WopiValidator.Core.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.2;net45</TargetFrameworks>
+    <TargetFrameworks>net6.0;</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../src/WopiValidatorSigningKey.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -26,7 +26,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This commit updates the projects to use .net6.0 and updates obsolete methods, which removes the warnings that show when running tests