### PR TITLE
Removing docker info and fixing options in readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM mcr.microsoft.com/dotnet/core/runtime:2.2
-
-COPY src/WopiValidator/bin/Release/netcoreapp2.2/publish/ /app/
-WORKDIR /app/
-
-ENTRYPOINT ["dotnet", "Microsoft.Office.WopiValidator.dll"]

--- a/README.md
+++ b/README.md
@@ -9,21 +9,6 @@
 This project contains the core logic of the [WOPI validator](https://wopi.readthedocs.io/en/latest/build_test_ship/validator.html)
 as well as a command-line interface to it.
 
-## Quick start using Docker
-
-You can quickly run the validator using Docker. First, pull the Docker image:
-
-`docker pull tylerbutler/wopi-validator`
-
-Then run the validator using a command like the following:
-
-`docker run -it --rm tylerbutler/wopi-validator -- -w http://localhost:5000/wopi/files/<id> -t myToken -l 0 -s`
-
-Note : The `--`; parameters after the `--` will be passed to the validator itself. The '<id>' must be an id that refers to a file with wopitest extension. The file must exist.
-
-**Tip:** Depending on your network configuration, you may also need to use the `--add-host` parameter to ensure
-the docker image can resolve your WOPI host domain name. Arguments to the `--add-host` parameter are of the form `host:IP`.
-
 ## Building the project
 
 The project can be built in Visual Studio 2017, Visual Studio Code, or using `dotnet build`:
@@ -59,15 +44,6 @@ with other platforms as needed).
 
 [1]: https://docs.microsoft.com/en-us/dotnet/core/deploying/deploy-with-cli
 
-### Building a Docker image
-
-You can build a Docker image locally from the Dockerfile in the root of the repository like so:
-
-```bash
-dotnet build -c Release
-docker build -t wopi-validator:latest -f Dockerfile .
-```
-
 ## Running tests
 
 Basic unit tests can be run using the `dotnet test` command:
@@ -88,11 +64,7 @@ Note: if you see any errors, you may need to build the project first, as describ
 
 There are several ways to run the validator.
 
-### Option 1: Docker
-
-See [the quick start](#quick-start-using-docker).
-
-### Option 2: `dotnet`
+### Option 1: `dotnet`
 
 After building the projects as described above, you can run the resulting `Microsoft.Office.WopiValidator.dll`
 using the `dotnet` command. For example:
@@ -101,7 +73,7 @@ using the `dotnet` command. For example:
 
 Note: the Microsoft.Office.WopiValidator.dll file can be found in `src\WopiValidator\bin\Release\netcoreapp2.0\`.
 
-### Option 3: `dotnet run --project`
+### Option 2: `dotnet run --project`
 
 You can also use the `dotnet run` command, passing the path to the `WopiValidator.csproj` file using the `--project`
 option. Arguments to the validator itself can be passed in by separating them from the `dotnet run` arguments with
@@ -109,7 +81,7 @@ a `--`. For example:
 
 `dotnet run --project ./src/WopiValidator/WopiValidator.csproj --framework net6.0 -- -t MyAccessToken -l 0 -w http://localhost:5000/wopi/files/<id> -e OfficeOnline -s`
 
-### Option 4: self-contained package
+### Option 3: self-contained package
 
 Another option is to build a self-contained package for your OS (see above) and execute the resulting executable
 file, which be called `Microsoft.Office.Validator.exe` on Windows and `Microsoft.Office.Validator` on Linux and macOS.
@@ -137,7 +109,9 @@ Copyright (C) 2018 Microsoft
 
   -e, --testcategory      (Default: All) Run only the tests in the specified category
 
-  -s, --ignore-skipped    Don't output any info about skipped tests.
+  -s, --ignore-skipped    Don't output any info about skipped tests
+
+  -d, --include-delaytests    Run test cases with delay
 
   --help                  Display this help screen.
 


### PR DESCRIPTION
Adding delay option in read me for test cases that are delayed for long duration to test expiration of locks. Also, removing docker since they are not up to date.