### PR TITLE
Added GUID's to file names during creation and rename

### DIFF
--- a/TestCases.xml
+++ b/TestCases.xml
@@ -1358,7 +1358,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeupname.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeupname.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
                 <AbsoluteUrlProperty Name="HostViewUrl" IsRequired="false" />
                 <AbsoluteUrlProperty Name="HostEditUrl" IsRequired="false" />
@@ -1385,7 +1385,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeupname.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeupname.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
                 <AbsoluteUrlProperty Name="HostViewUrl" IsRequired="false" />
                 <AbsoluteUrlProperty Name="HostEditUrl" IsRequired="false" />
@@ -1412,7 +1412,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeupname.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeupname.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
                 <AbsoluteUrlProperty Name="HostViewUrl" IsRequired="false" />
                 <AbsoluteUrlProperty Name="HostEditUrl" IsRequired="false" />
@@ -1438,7 +1438,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeupname.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeupname.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
                 <AbsoluteUrlProperty Name="HostViewUrl" IsRequired="false" />
                 <AbsoluteUrlProperty Name="HostEditUrl" IsRequired="false" />
@@ -1469,7 +1469,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeupname.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeupname.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
                 <AbsoluteUrlProperty Name="HostViewUrl" IsRequired="false" />
                 <AbsoluteUrlProperty Name="HostEditUrl" IsRequired="false" />
@@ -1499,7 +1499,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeupname.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeupname.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
                 <AbsoluteUrlProperty Name="HostViewUrl" IsRequired="false" />
                 <AbsoluteUrlProperty Name="HostEditUrl" IsRequired="false" />
@@ -1561,7 +1561,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeupname.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeupname.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
                 <AbsoluteUrlProperty Name="HostViewUrl" IsRequired="false" />
                 <AbsoluteUrlProperty Name="HostEditUrl" IsRequired="false" />
@@ -1593,7 +1593,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeup_name.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeup_name.wopitestx" />
               </JsonResponseContentValidator>
             </Validators>
           </PutRelativeFile>
@@ -1768,7 +1768,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" />
               </JsonResponseContentValidator>
             </Validators>
           </PutRelativeFile>
@@ -1785,7 +1785,7 @@
             <Validators>
               <ResponseCodeValidator ExpectedCode="200" />
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFileRenamed" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFileRenamed" />
               </JsonResponseContentValidator>
             </Validators>
           </RenameFile>
@@ -1808,7 +1808,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeup_name.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeup_name.wopitestx" />
               </JsonResponseContentValidator>
             </Validators>
           </PutRelativeFile>
@@ -1825,7 +1825,7 @@
             <Validators>
               <ResponseCodeValidator ExpectedCode="200" />
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeup_renamed" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeup_renamed" />
               </JsonResponseContentValidator>
             </Validators>
           </RenameFile>
@@ -1847,7 +1847,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" />
               </JsonResponseContentValidator>
             </Validators>
           </PutRelativeFile>
@@ -1865,7 +1865,7 @@
             <Validators>
               <ResponseCodeValidator ExpectedCode="200" />
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFileRenamed" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFileRenamed" />
               </JsonResponseContentValidator>
             </Validators>
           </RenameFile>
@@ -1890,7 +1890,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" />
               </JsonResponseContentValidator>
             </Validators>
           </PutRelativeFile>
@@ -1929,7 +1929,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" />
               </JsonResponseContentValidator>
             </Validators>
           </PutRelativeFile>
@@ -1965,7 +1965,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" />
               </JsonResponseContentValidator>
             </Validators>
           </PutRelativeFile>
@@ -1982,14 +1982,14 @@
             <Validators>
               <ResponseCodeValidator ExpectedCode="200" />
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFileRenamed" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFileRenamed" />
               </JsonResponseContentValidator>
             </Validators>
           </RenameFile>
           <CheckFileInfo OverrideUrl="$State:NewFileUrl">
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="BaseFileName" ExpectedValue="ValidatorTestFileRenamed.wopitest" IsRequired="true" />
+                <FileNameProperty Name="BaseFileName" ExpectedValue="ValidatorTestFileRenamed.wopitest" />
                 <StringProperty Name="FileExtension" ExpectedValue=".wopitest" IsRequired="false" />
               </JsonResponseContentValidator>
             </Validators>
@@ -2033,7 +2033,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
               </JsonResponseContentValidator>
             </Validators>
@@ -2051,7 +2051,7 @@
             <Validators>
               <ResponseCodeValidator ExpectedCode="200" />
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFileRenamed" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFileRenamed" />
               </JsonResponseContentValidator>
             </Validators>
           </RenameFile>
@@ -2080,7 +2080,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeup_name.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeup_name.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
               </JsonResponseContentValidator>
             </Validators>
@@ -2098,7 +2098,7 @@
             <Validators>
               <ResponseCodeValidator ExpectedCode="200" />
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeup_renamed" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeup_renamed" />
               </JsonResponseContentValidator>
             </Validators>
           </RenameFile>
@@ -2126,7 +2126,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
               </JsonResponseContentValidator>
             </Validators>
@@ -2145,7 +2145,7 @@
             <Validators>
               <ResponseCodeValidator ExpectedCode="200" />
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFileRenamed" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFileRenamed" />
               </JsonResponseContentValidator>
             </Validators>
           </RenameFile>
@@ -2176,7 +2176,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
               </JsonResponseContentValidator>
             </Validators>
@@ -2222,7 +2222,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
               </JsonResponseContentValidator>
             </Validators>
@@ -2265,7 +2265,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFile.wopitest" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
               </JsonResponseContentValidator>
             </Validators>
@@ -2283,14 +2283,14 @@
             <Validators>
               <ResponseCodeValidator ExpectedCode="200" />
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="ValidatorTestFileRenamed" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="ValidatorTestFileRenamed" />
               </JsonResponseContentValidator>
             </Validators>
           </RenameFile>
           <CheckFileInfo OverrideUrl="$State:NewFileUrl">
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="BaseFileName" ExpectedValue="ValidatorTestFileRenamed.wopitest" IsRequired="true" />
+                <FileNameProperty Name="BaseFileName" ExpectedValue="ValidatorTestFileRenamed.wopitest" />
                 <StringProperty Name="FileExtension" ExpectedValue=".wopitest" IsRequired="false" />
               </JsonResponseContentValidator>
             </Validators>
@@ -3037,7 +3037,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeupname.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeupname.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
                 <AbsoluteUrlProperty Name="HostViewUrl" IsRequired="false" />
                 <AbsoluteUrlProperty Name="HostEditUrl" IsRequired="false" />
@@ -3076,7 +3076,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeupname.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeupname.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
                 <AbsoluteUrlProperty Name="HostViewUrl" IsRequired="false" />
                 <AbsoluteUrlProperty Name="HostEditUrl" IsRequired="false" />
@@ -3115,7 +3115,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeupname.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeupname.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
                 <AbsoluteUrlProperty Name="HostViewUrl" IsRequired="false" />
                 <AbsoluteUrlProperty Name="HostEditUrl" IsRequired="false" />
@@ -3154,7 +3154,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeupname.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeupname.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
                 <AbsoluteUrlProperty Name="HostViewUrl" IsRequired="false" />
                 <AbsoluteUrlProperty Name="HostEditUrl" IsRequired="false" />
@@ -3198,7 +3198,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeupname.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeupname.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
                 <AbsoluteUrlProperty Name="HostViewUrl" IsRequired="false" />
                 <AbsoluteUrlProperty Name="HostEditUrl" IsRequired="false" />
@@ -3242,7 +3242,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeupname.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeupname.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
                 <AbsoluteUrlProperty Name="HostViewUrl" IsRequired="false" />
                 <AbsoluteUrlProperty Name="HostEditUrl" IsRequired="false" />
@@ -3327,7 +3327,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeupname.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeupname.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
                 <AbsoluteUrlProperty Name="HostViewUrl" IsRequired="false" />
                 <AbsoluteUrlProperty Name="HostEditUrl" IsRequired="false" />
@@ -3372,7 +3372,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeup_name.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeup_name.wopitestx" />
               </JsonResponseContentValidator>
             </Validators>
           </CreateChildFile>
@@ -3446,7 +3446,7 @@
             </SaveState>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="madeupname.wopitestx" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="madeupname.wopitestx" />
                 <AbsoluteUrlProperty Name="Url" IsRequired="true" MustIncludeAccessToken="true" />
               </JsonResponseContentValidator>
             </Validators>
@@ -7355,14 +7355,14 @@
             <Validators>
               <ResponseCodeValidator ExpectedCode="200" />
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="RenameFile_ClientPresentsCoauthLockWithHostCoauthLock" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="RenameFile_ClientPresentsCoauthLockWithHostCoauthLock" />
               </JsonResponseContentValidator>
             </Validators>
           </RenameFile>
           <CheckFileInfo>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="BaseFileName" ExpectedValue="RenameFile_ClientPresentsCoauthLockWithHostCoauthLock.wopitest" IsRequired="true" />
+                <FileNameProperty Name="BaseFileName" ExpectedValue="RenameFile_ClientPresentsCoauthLockWithHostCoauthLock.wopitest" />
               </JsonResponseContentValidator>
             </Validators>
           </CheckFileInfo>
@@ -7397,14 +7397,14 @@
             <Validators>
               <ResponseCodeValidator ExpectedCode="200" />
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="RenameFile_ClientPresentsCoauthLockWithHostNoLock" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="RenameFile_ClientPresentsCoauthLockWithHostNoLock" />
               </JsonResponseContentValidator>
             </Validators>
           </RenameFile>
           <CheckFileInfo>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="BaseFileName" ExpectedValue="RenameFile_ClientPresentsCoauthLockWithHostNoLock.wopitest" IsRequired="true" />
+                <FileNameProperty Name="BaseFileName" ExpectedValue="RenameFile_ClientPresentsCoauthLockWithHostNoLock.wopitest" />
               </JsonResponseContentValidator>
             </Validators>
           </CheckFileInfo>
@@ -7419,14 +7419,14 @@
             <Validators>
               <ResponseCodeValidator ExpectedCode="200" />
               <JsonResponseContentValidator>
-                <StringProperty Name="Name" ExpectedValue="RenameFile_ClientPresentsNoLockWithHostNoLock" IsRequired="true" />
+                <FileNameProperty Name="Name" ExpectedValue="RenameFile_ClientPresentsNoLockWithHostNoLock" />
               </JsonResponseContentValidator>
             </Validators>
           </RenameFile>
           <CheckFileInfo>
             <Validators>
               <JsonResponseContentValidator>
-                <StringProperty Name="BaseFileName" ExpectedValue="RenameFile_ClientPresentsNoLockWithHostNoLock.wopitest" IsRequired="true" />
+                <FileNameProperty Name="BaseFileName" ExpectedValue="RenameFile_ClientPresentsNoLockWithHostNoLock.wopitest" />
               </JsonResponseContentValidator>
             </Validators>
           </CheckFileInfo>

--- a/TestCases.xsd
+++ b/TestCases.xsd
@@ -54,6 +54,13 @@
                         <xs:attribute name="IgnoreCase" type="xs:boolean" use="optional" default="false" />
                       </xs:complexType>
                     </xs:element>
+                    <xs:element name="FileNameProperty">
+                      <xs:complexType>
+                        <xs:attribute name="Name" type="xs:string" use="required" />
+                        <xs:attribute name="ExpectedValue" type="xs:string" use="required" />
+                        <xs:attribute name="IgnoreCase" type="xs:boolean" use="optional" default="false" />
+                      </xs:complexType>
+                    </xs:element>
                     <xs:element name="StringRegexProperty">
                       <xs:complexType>
                         <xs:attribute name="Name" type="xs:string" use="required" />

--- a/src/WopiValidator.Core/Constants.cs
+++ b/src/WopiValidator.Core/Constants.cs
@@ -156,6 +156,7 @@ namespace Microsoft.Office.WopiValidator.Core
 				public const string ResponseBodyProperty = "ResponseBodyProperty";
 				public const string StringRegexProperty = "StringRegexProperty";
 				public const string StringProperty = "StringProperty";
+				public const string FileNameProperty = "FileNameProperty";
 			}
 		}
 

--- a/src/WopiValidator.Core/Factories/RequestFactory.cs
+++ b/src/WopiValidator.Core/Factories/RequestFactory.cs
@@ -16,15 +16,15 @@ namespace Microsoft.Office.WopiValidator.Core.Factories
 		/// <summary>
 		/// Parses requests information from XML into a collection of IWopiRequest
 		/// </summary>
-		public static IEnumerable<IRequest> GetRequests(XElement definition)
+		public static IEnumerable<IRequest> GetRequests(XElement definition, string fileNameGuid)
 		{
-			return definition.Elements().Select(GetRequest);
+			return definition.Elements().Select(x => GetRequest(x, fileNameGuid));
 		}
 
 		/// <summary>
 		/// Parses single request definition and instantiates proper IWopiRequest instance based on element name
 		/// </summary>
-		private static IRequest GetRequest(XElement definition)
+		private static IRequest GetRequest(XElement definition, string fileNameGuid)
 		{
 			string elementName = definition.Name.LocalName;
 			XElement validatorsDefinition = definition.Element("Validators");
@@ -32,7 +32,7 @@ namespace Microsoft.Office.WopiValidator.Core.Factories
 			XElement mutatorsDefinition = definition.Element("Mutators");
 			XElement requestBodyDefinition = definition.Element("RequestBody");
 
-			IEnumerable<IValidator> validators = validatorsDefinition == null ? null : ValidatorFactory.GetValidators(validatorsDefinition);
+			IEnumerable<IValidator> validators = validatorsDefinition == null ? null : ValidatorFactory.GetValidators(validatorsDefinition, fileNameGuid);
 			IEnumerable<IStateEntry> stateSavers = stateDefinition == null ? null : StateFactory.GetStateExpressions(stateDefinition);
 			IEnumerable<IMutator> mutators = mutatorsDefinition == null ? null : MutatorFactory.GetMutators(mutatorsDefinition);
 
@@ -173,7 +173,7 @@ namespace Microsoft.Office.WopiValidator.Core.Factories
 				case Constants.Requests.PutFile:
 					return new PutFileWopiRequest(wopiRequestParams);
 				case Constants.Requests.PutRelativeFile:
-					return new PutRelativeFileWopiRequest(wopiRequestParams);
+					return new PutRelativeFileWopiRequest(wopiRequestParams, fileNameGuid);
 				case Constants.Requests.CheckEcosystem:
 					return new CheckEcosystemRequest(wopiRequestParams);
 				case Constants.Requests.GetNewAccessToken:
@@ -191,7 +191,7 @@ namespace Microsoft.Office.WopiValidator.Core.Factories
 				case Constants.Requests.CreateChildContainer:
 					return new CreateChildContainerRequest(wopiRequestParams);
 				case Constants.Requests.CreateChildFile:
-					return new CreateChildFileRequest(wopiRequestParams);
+					return new CreateChildFileRequest(wopiRequestParams, fileNameGuid);
 				case Constants.Requests.DeleteFile:
 					return new DeleteFileRequest(wopiRequestParams);
 				case Constants.Requests.DeleteContainer:
@@ -199,7 +199,7 @@ namespace Microsoft.Office.WopiValidator.Core.Factories
 				case Constants.Requests.RenameContainer:
 					return new RenameContainerRequest(wopiRequestParams);
 				case Constants.Requests.RenameFile:
-					return new RenameFileRequest(wopiRequestParams);
+					return new RenameFileRequest(wopiRequestParams, fileNameGuid);
 				case Constants.Requests.GetFromFileUrl:
 					return new GetFromFileUrlRequest(wopiRequestParams);
 				case Constants.Requests.GetShareUrl:

--- a/src/WopiValidator.Core/Factories/TestCaseFactory.cs
+++ b/src/WopiValidator.Core/Factories/TestCaseFactory.cs
@@ -57,14 +57,15 @@ namespace Microsoft.Office.WopiValidator.Core.Factories
 			string uiScreenshot = (string)definition.Attribute("UiScreenshot");
 			string documentationLink = (string)definition.Attribute("DocumentationLink");
 			string failMessage = (string)definition.Attribute("FailMessage");
+			string fileNameGuid = Guid.NewGuid().ToString();
 
 			XElement requestsDefinition = definition.Element("Requests");
-			IEnumerable<IRequest> requests = RequestFactory.GetRequests(requestsDefinition);
+			IEnumerable<IRequest> requests = RequestFactory.GetRequests(requestsDefinition, fileNameGuid);
 
 			IEnumerable<IRequest> cleanupRequests = null;
 			XElement cleanupRequestsDefinition = definition.Element("CleanupRequests");
 			if (cleanupRequestsDefinition != null)
-				cleanupRequests = RequestFactory.GetRequests(cleanupRequestsDefinition);
+				cleanupRequests = RequestFactory.GetRequests(cleanupRequestsDefinition, fileNameGuid);
 
 			ITestCase testCase = new TestCase(requests,
 				cleanupRequests,

--- a/src/WopiValidator.Core/Requests/CreateChildFileRequest.cs
+++ b/src/WopiValidator.Core/Requests/CreateChildFileRequest.cs
@@ -8,9 +8,12 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 {
 	class CreateChildFileRequest : WopiRequest
 	{
-		public CreateChildFileRequest(WopiRequestParam param) : base(param)
+		public CreateChildFileRequest(WopiRequestParam param, string guid) : base(param)
 		{
-			this.RequestedName = param.RequestedName;
+			this.RequestedName = string.Format("{0}-{1}{2}",
+				System.IO.Path.GetFileNameWithoutExtension(param.RequestedName),
+				guid,
+				System.IO.Path.GetExtension(param.RequestedName));
 			this.RequestType = param.PutRelativeFileMode;
 			this.OverwriteRelative = param.OverwriteRelative;
 		}

--- a/src/WopiValidator.Core/Requests/PutRelativeFileWopiRequest.cs
+++ b/src/WopiValidator.Core/Requests/PutRelativeFileWopiRequest.cs
@@ -4,17 +4,18 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Microsoft.Office.WopiValidator.Core.Requests
 {
 	class PutRelativeFileWopiRequest : WopiRequest
 	{
-		public PutRelativeFileWopiRequest(WopiRequestParam param) : base(param)
+		public PutRelativeFileWopiRequest(WopiRequestParam param, string guid) : base(param)
 		{
 			this.ResourceId = param.ResourceId;
 			if (string.IsNullOrEmpty(param.RequestedName))
 				throw new ArgumentException("Requested name for a PutRelativeFile Wopi request cannot be null or empty");
-			this.RequestedName = param.RequestedName;
+			this.RequestedName = string.Format("{0}-{1}", param.RequestedName, guid);
 			this.RequestType = param.PutRelativeFileMode;
 			this.OverwriteRelative = param.OverwriteRelative;
 		}

--- a/src/WopiValidator.Core/Requests/RenameFileRequest.cs
+++ b/src/WopiValidator.Core/Requests/RenameFileRequest.cs
@@ -8,11 +8,11 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 {
 	class RenameFileRequest : WopiRequest
 	{
-		public RenameFileRequest(WopiRequestParam param) : base(param)
+		public RenameFileRequest(WopiRequestParam param, string guid) : base(param)
 		{
 			this.LockString = param.LockString;
 			this.CoauthLockId = param.CoauthLockId;
-			this.RequestedName = param.RequestedName;
+			this.RequestedName = string.Format("{0}-{1}", param.RequestedName, guid);
 		}
 
 		public string LockString { get; private set; }

--- a/src/WopiValidator.Core/Validators/JsonContentValidator.cs
+++ b/src/WopiValidator.Core/Validators/JsonContentValidator.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Office.WopiValidator.Core.Validators
 				return isValid;
 			}
 
-			public T DefaultExpectedValue { get; private set; }
+			public T DefaultExpectedValue { get; protected set; }
 
 			public bool HasExpectedValue { get; private set; }
 
@@ -362,6 +362,18 @@ namespace Microsoft.Office.WopiValidator.Core.Validators
 				errorMessage = string.Format(CultureInfo.CurrentCulture, "Expected: '{0} (case-insensitive)', Actual: '{1}'", expectedValue, formattedActualValue);
 				return isValid;
 			}
+		}
+
+		public class JsonFileNamePropertyValidator : JsonStringPropertyValidator
+		{
+			public JsonFileNamePropertyValidator(string key, string expectedValue, string guid, bool ignoreCase = false)
+				: base(key, true, expectedValue, true, null, null, ignoreCase)
+				{
+					DefaultExpectedValue = string.Format("{0}-{1}{2}",
+						System.IO.Path.GetFileNameWithoutExtension(DefaultExpectedValue),
+						guid,
+						System.IO.Path.GetExtension(DefaultExpectedValue));
+				}
 		}
 
 		public class JsonStringRegexPropertyValidator : JsonPropertyEqualityValidator<string>


### PR DESCRIPTION
For each test case, we should make any file names unique so that different test cases and/or validator runs don't conflict with each other. We can accomplish this by generating a GUID for each test case and appending it to any filenames as needed.