### PR TITLE
Adding sequence number check and coauthlockmetadata test cases

### DIFF
--- a/TestCases.xml
+++ b/TestCases.xml
@@ -858,7 +858,7 @@
           <Unlock Lock="LockString" />
           <GetLock>
             <Validators>
-              <ResponseHeaderValidator Header="X-WOPI-Lock" ExpectedValue="" IsRequired="true" ShouldMatch="true" />
+              <ResponseHeaderValidator Header="X-WOPI-Lock" ExpectedValue="" ShouldMatch="true" />
             </Validators>
           </GetLock>
         </Requests>
@@ -5512,6 +5512,290 @@
           </Unlock>
         </CleanupRequests>
       </TestCase>
+      <TestCase Name="CoauthLock.CoauthLockMetadataSentAsBody" Category="WopiCoauth">
+        <Description>
+          Tests that a coauth lock's metadata is handled properly when coauthlockmetadata is sent as part of body.
+        </Description>
+        <Requests>
+          <GetCoauthLock CoauthLockId="Client1" CoauthLockExpirationTimeout="120" CoauthLockMetadataAsBody="CoauthLockMetadataAsBody" CoauthLockType="Coauth">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+            </Validators>
+          </GetCoauthLock>
+          <GetCoauthTable>
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+              <JsonSchemaValidator Schema="CoauthTableSchema" />
+              <JsonResponseContentValidator>
+                <ResponseBodyProperty Name="CoauthTable" ExpectedValue="[{CoauthLockId:'Client1', CoauthLockMetadata:'CoauthLockMetadataAsBody', CoauthLockType:'Coauth', UserFriendlyName:'*', CoauthLockTime:'*'}]" IsRequired="true" />
+                <ArrayLengthProperty Name="CoauthTable" ExpectedValue="1" IsRequired="true" />
+              </JsonResponseContentValidator>
+            </Validators>
+          </GetCoauthTable>
+        </Requests>
+        <CleanupRequests>
+          <UnlockCoauthLock CoauthLockId="Client1">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+            </Validators>
+          </UnlockCoauthLock>
+        </CleanupRequests>
+      </TestCase>
+      <TestCase Name="CoauthLock.CoauthLockMetadataSentAsBodyForRefreshCoauthLock" Category="WopiCoauth">
+        <Description>
+          Tests that a coauth lock's metadata is handled properly when coauthlockmetadata is sent as part of body.
+        </Description>
+        <Requests>
+          <GetCoauthLock CoauthLockId="Client1" CoauthLockExpirationTimeout="120" CoauthLockMetadataAsBody="CoauthLockMetadataAsBody" CoauthLockType="Coauth">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+            </Validators>
+          </GetCoauthLock>
+          <RefreshCoauthLock CoauthLockId="Client1" CoauthLockExpirationTimeout="120" CoauthLockMetadataAsBody="CoauthLockMetadataAsBody2">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+            </Validators>
+          </RefreshCoauthLock>
+          <GetCoauthTable>
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+              <JsonSchemaValidator Schema="CoauthTableSchema" />
+              <JsonResponseContentValidator>
+                <ResponseBodyProperty Name="CoauthTable" ExpectedValue="[{CoauthLockId:'Client1', CoauthLockMetadata:'CoauthLockMetadataAsBody2', CoauthLockType:'Coauth', UserFriendlyName:'*', CoauthLockTime:'*'}]" IsRequired="true" />
+                <ArrayLengthProperty Name="CoauthTable" ExpectedValue="1" IsRequired="true" />
+              </JsonResponseContentValidator>
+            </Validators>
+          </GetCoauthTable>
+        </Requests>
+        <CleanupRequests>
+          <UnlockCoauthLock CoauthLockId="Client1">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+            </Validators>
+          </UnlockCoauthLock>
+        </CleanupRequests>
+      </TestCase>
+      <TestCase Name="CoauthLock.CoauthLockMetadataSentAsBodyAndHeader" Category="WopiCoauth">
+        <Description>
+          Tests that a coauth lock's metadata is handled properly when coauthlockmetadata is sent as part of body and header. Body value is given preference over header
+        </Description>
+        <Requests>
+          <GetCoauthLock CoauthLockId="Client1" CoauthLockExpirationTimeout="120" CoauthLockMetadata="CoauthLockMetadata" CoauthLockMetadataAsBody="CoauthLockMetadataAsBody" CoauthLockType="Coauth">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+            </Validators>
+          </GetCoauthLock>
+          <GetCoauthTable>
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+              <JsonSchemaValidator Schema="CoauthTableSchema" />
+              <JsonResponseContentValidator>
+                <ResponseBodyProperty Name="CoauthTable" ExpectedValue="[{CoauthLockId:'Client1', CoauthLockMetadata:'CoauthLockMetadataAsBody', CoauthLockType:'Coauth', UserFriendlyName:'*', CoauthLockTime:'*'}]" IsRequired="true" />
+                <ArrayLengthProperty Name="CoauthTable" ExpectedValue="1" IsRequired="true" />
+              </JsonResponseContentValidator>
+            </Validators>
+          </GetCoauthTable>
+        </Requests>
+        <CleanupRequests>
+          <UnlockCoauthLock CoauthLockId="Client1">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+            </Validators>
+          </UnlockCoauthLock>
+        </CleanupRequests>
+      </TestCase>
+      <TestCase Name="CoauthLock.CoauthLockMetadataSentAsBodyAndHeaderForRefreshCoauthLock" Category="WopiCoauth">
+        <Description>
+          Tests that a coauth lock's metadata is handled properly when coauthlockmetadata is sent as part of body and header. Body value is given preference over header.
+        </Description>
+        <Requests>
+          <GetCoauthLock CoauthLockId="Client1" CoauthLockExpirationTimeout="120" CoauthLockMetadata="CoauthLockMetadata" CoauthLockMetadataAsBody="CoauthLockMetadataAsBody" CoauthLockType="Coauth">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+            </Validators>
+          </GetCoauthLock>
+          <RefreshCoauthLock CoauthLockId="Client1" CoauthLockExpirationTimeout="120" CoauthLockMetadata="CoauthLockMetadata2" CoauthLockMetadataAsBody="CoauthLockMetadataAsBody2">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+            </Validators>
+          </RefreshCoauthLock>
+          <GetCoauthTable>
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+              <JsonSchemaValidator Schema="CoauthTableSchema" />
+              <JsonResponseContentValidator>
+                <ResponseBodyProperty Name="CoauthTable" ExpectedValue="[{CoauthLockId:'Client1', CoauthLockMetadata:'CoauthLockMetadataAsBody2', CoauthLockType:'Coauth', UserFriendlyName:'*', CoauthLockTime:'*'}]" IsRequired="true" />
+                <ArrayLengthProperty Name="CoauthTable" ExpectedValue="1" IsRequired="true" />
+              </JsonResponseContentValidator>
+            </Validators>
+          </GetCoauthTable>
+        </Requests>
+        <CleanupRequests>
+          <UnlockCoauthLock CoauthLockId="Client1">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+            </Validators>
+          </UnlockCoauthLock>
+        </CleanupRequests>
+      </TestCase>
+      <TestCase Name="CoauthLock.CoauthLockMetadataSentAsBodyAndHeaderForMultipleLocks" Category="WopiCoauth">
+        <Description>
+          Tests that a coauth lock's metadata is handled properly when coauthlockmetadata is sent as part of body and header. Body value is given preference over header.
+        </Description>
+        <Requests>
+          <GetCoauthLock CoauthLockId="Client1" CoauthLockExpirationTimeout="120" CoauthLockMetadata="CoauthLockMetadata" CoauthLockMetadataAsBody="CoauthLockMetadataAsBody" CoauthLockType="Coauth">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+            </Validators>
+          </GetCoauthLock>
+          <RefreshCoauthLock CoauthLockId="Client1" CoauthLockExpirationTimeout="120" CoauthLockMetadata="CoauthLockMetadata2" CoauthLockMetadataAsBody="CoauthLockMetadataAsBodyClient1">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+            </Validators>
+          </RefreshCoauthLock>
+          <GetCoauthLock CoauthLockId="Client2" CoauthLockExpirationTimeout="120" CoauthLockMetadataAsBody="CoauthLockMetadataAsBodyClient2" CoauthLockType="Coauth">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+            </Validators>
+          </GetCoauthLock>
+          <GetCoauthTable>
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+              <JsonSchemaValidator Schema="CoauthTableSchema" />
+              <JsonResponseContentValidator>
+                <ResponseBodyProperty Name="CoauthTable" ExpectedValue="[{CoauthLockId:'Client1', CoauthLockMetadata:'CoauthLockMetadataAsBodyClient1', CoauthLockType:'Coauth', UserFriendlyName:'*', CoauthLockTime:'*'},{CoauthLockId:'Client2', CoauthLockMetadata:'CoauthLockMetadataAsBodyClient2', CoauthLockType:'Coauth', UserFriendlyName:'*', CoauthLockTime:'*'}]" IsRequired="true" />
+                <ArrayLengthProperty Name="CoauthTable" ExpectedValue="2" IsRequired="true" />
+              </JsonResponseContentValidator>
+            </Validators>
+          </GetCoauthTable>
+        </Requests>
+        <CleanupRequests>
+          <UnlockCoauthLock CoauthLockId="Client1">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+            </Validators>
+          </UnlockCoauthLock>
+          <UnlockCoauthLock CoauthLockId="Client2">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+            </Validators>
+          </UnlockCoauthLock>
+        </CleanupRequests>
+      </TestCase>
+      <TestCase Name="CoauthLock.CoauthLockMetadataSentAsBodyAndHeaderSetToEmpty" Category="WopiCoauth">
+        <Description>
+          Tests that a coauth lock's metadata is handled properly when coauthlockmetadata is sent as part of body and header. Body value is given preference over header and set to empty.
+        </Description>
+        <Requests>
+          <GetCoauthLock CoauthLockId="Client1" CoauthLockExpirationTimeout="120" CoauthLockMetadata="CoauthLockMetadata" CoauthLockMetadataAsBody="" CoauthLockType="Coauth">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+            </Validators>
+          </GetCoauthLock>
+          <GetCoauthTable>
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+              <JsonSchemaValidator Schema="CoauthTableSchema" />
+              <JsonResponseContentValidator>
+                <ResponseBodyProperty Name="CoauthTable" ExpectedValue="[{CoauthLockId:'Client1', CoauthLockMetadata:'', CoauthLockType:'Coauth', UserFriendlyName:'*', CoauthLockTime:'*'}]" IsRequired="true" />
+                <ArrayLengthProperty Name="CoauthTable" ExpectedValue="1" IsRequired="true" />
+              </JsonResponseContentValidator>
+            </Validators>
+          </GetCoauthTable>
+        </Requests>
+        <CleanupRequests>
+          <UnlockCoauthLock CoauthLockId="Client1">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+            </Validators>
+          </UnlockCoauthLock>
+        </CleanupRequests>
+      </TestCase>
+      <TestCase Name="CoauthLock.CoauthLockMetadataSentAsBodySetToEmpty" Category="WopiCoauth">
+        <Description>
+          Tests that a coauth lock's metadata is handled properly when coauthlockmetadata is sent as part of body. Body value is set to empty.
+        </Description>
+        <Requests>
+          <GetCoauthLock CoauthLockId="Client1" CoauthLockExpirationTimeout="120" CoauthLockMetadataAsBody="" CoauthLockType="Coauth">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+            </Validators>
+          </GetCoauthLock>
+          <GetCoauthTable>
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+              <JsonSchemaValidator Schema="CoauthTableSchema" />
+              <JsonResponseContentValidator>
+                <ResponseBodyProperty Name="CoauthTable" ExpectedValue="[{CoauthLockId:'Client1', CoauthLockMetadata:'', CoauthLockType:'Coauth', UserFriendlyName:'*', CoauthLockTime:'*'}]" IsRequired="true" />
+                <ArrayLengthProperty Name="CoauthTable" ExpectedValue="1" IsRequired="true" />
+              </JsonResponseContentValidator>
+            </Validators>
+          </GetCoauthTable>
+        </Requests>
+        <CleanupRequests>
+          <UnlockCoauthLock CoauthLockId="Client1">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+            </Validators>
+          </UnlockCoauthLock>
+        </CleanupRequests>
+      </TestCase>
+      <TestCase Name="CoauthLock.CoauthLockMetadataSentAsBodySetToEmptyRefreshCoauthLock" Category="WopiCoauth">
+        <Description>
+          Tests that a coauth lock's metadata is handled properly when coauthlockmetadata is sent as part of body. Body value is set to empty.
+          If present and empty or null, the CoauthLockMetadata value remains unchanged. If present and is set to a non-empty string, CoauthLockMetadata is overwritten with that value.
+        </Description>
+        <Requests>
+          <GetCoauthLock CoauthLockId="Client1" CoauthLockExpirationTimeout="120" CoauthLockMetadataAsBody="CoauthLockMetadataAsBody" CoauthLockType="Coauth">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+            </Validators>
+          </GetCoauthLock>
+          <RefreshCoauthLock CoauthLockId="Client1" CoauthLockExpirationTimeout="120" CoauthLockMetadataAsBody="">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+            </Validators>
+          </RefreshCoauthLock>
+          <GetCoauthTable>
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+              <ResponseHeaderValidator Header="X-WOPI-CoauthTableVersion" IsRequired="true" />
+              <JsonSchemaValidator Schema="CoauthTableSchema" />
+              <JsonResponseContentValidator>
+                <ResponseBodyProperty Name="CoauthTable" ExpectedValue="[{CoauthLockId:'Client1', CoauthLockMetadata:'CoauthLockMetadataAsBody', CoauthLockType:'Coauth', UserFriendlyName:'*', CoauthLockTime:'*'}]" IsRequired="true" />
+                <ArrayLengthProperty Name="CoauthTable" ExpectedValue="1" IsRequired="true" />
+              </JsonResponseContentValidator>
+            </Validators>
+          </GetCoauthTable>
+        </Requests>
+        <CleanupRequests>
+          <UnlockCoauthLock CoauthLockId="Client1">
+            <Validators>
+              <ResponseCodeValidator ExpectedCode="200" />
+            </Validators>
+          </UnlockCoauthLock>
+        </CleanupRequests>
+      </TestCase>
     </TestCases>
   </TestGroup>
 
@@ -5857,6 +6141,7 @@
               <ContentStream ChunkingScheme="FullFile" StreamId="MainContent" NewContent="SampleTextVersion-1" LastKnownHostContent="" />
             </ContentStreams>
             <Validators>
+              <ResponseHeaderValidator Header="X-WOPI-SequenceNumber" IsRequired="true" />
               <ResponseCodeValidator ExpectedCode="412" />
             </Validators>
           </PutChunkedFile>

--- a/TestCases.xsd
+++ b/TestCases.xsd
@@ -374,6 +374,7 @@
     <xs:attribute name="CoauthLockMetadata" type="xs:string" use="optional"/>
     <xs:attribute name="CoauthLockId" type="xs:string" use="required"/>
     <xs:attribute name="CoauthLockExpirationTimeout" type="xs:unsignedInt" use="required"/>
+    <xs:attribute name="CoauthLockMetadataAsBody" type="xs:string" />
   </xs:complexType>
 
   <xs:complexType name="GetCoauthTable">
@@ -395,6 +396,7 @@
     <xs:attribute name="CoauthLockMetadata" type="xs:string" use="optional"/>
     <xs:attribute name="CoauthLockId" type="xs:string" use="required"/>
     <xs:attribute name="CoauthLockExpirationTimeout" type="xs:unsignedInt" use="required"/>
+    <xs:attribute name="CoauthLockMetadataAsBody" type="xs:string" />
   </xs:complexType>
 
   <xs:complexType name="UnlockCoauthLock">

--- a/src/WopiValidator.Core/Factories/RequestFactory.cs
+++ b/src/WopiValidator.Core/Factories/RequestFactory.cs
@@ -86,6 +86,17 @@ namespace Microsoft.Office.WopiValidator.Core.Factories
 				UploadSessionTokenToCommit = uploadSessionTokenToCommit
 			};
 
+			string coauthLockMetadataAsBody = (string)definition.Attribute("CoauthLockMetadataAsBody");
+			if (coauthLockMetadataAsBody != null)
+			{
+				wopiRequestParams.CoauthLockMetadataAsBody = new CoauthLockMetadataEntity();
+				wopiRequestParams.CoauthLockMetadataAsBody.CoauthLockMetadata = coauthLockMetadataAsBody;
+			}
+			else
+			{
+				wopiRequestParams.CoauthLockMetadataAsBody = null;
+			}
+
 			if (requestBodyDefinition != null && !String.IsNullOrEmpty(requestBodyDefinition.Value))
 			{
 				wopiRequestParams.RequestBody = requestBodyDefinition.Value;

--- a/src/WopiValidator.Core/Factories/ValidatorFactory.cs
+++ b/src/WopiValidator.Core/Factories/ValidatorFactory.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Office.WopiValidator.Core.Factories
 			string comparator = (string)definition.Attribute("Comparator");
 			string expectedStateKey = (string)definition.Attribute("ExpectedStateKey");
 			string expectedValue = (string)definition.Attribute("ExpectedValue");
-			bool isRequired = ((bool?)definition.Attribute("IsRequired")) ?? true;
+			bool isRequired = ((bool?)definition.Attribute("IsRequired")) ?? false;
 			bool shouldMatch = ((bool?)definition.Attribute("ShouldMatch")) ?? true;
 
 			return new ResponseHeaderValidator(header, expectedValue, expectedStateKey, comparator, isRequired, shouldMatch);

--- a/src/WopiValidator.Core/IncrementalFileTransfer/JsonDataContracts.cs
+++ b/src/WopiValidator.Core/IncrementalFileTransfer/JsonDataContracts.cs
@@ -276,4 +276,25 @@ namespace Microsoft.Office.WopiValidator.Core.IncrementalFileTransfer
 				Length);
 		}
 	}
+
+
+	[DataContract]
+	internal class WopiCoauthLockMetadata
+	{
+		/// <summary>
+		/// A string set by client when requesting the lock
+		/// </summary>
+		[DataMember]
+		public string CoauthLockMetadata { get; set; }
+
+		public WopiCoauthLockMetadata()
+		{
+			CoauthLockMetadata = string.Empty;
+		}
+
+		public override string ToString()
+		{
+			return string.Format("CoauthLockMetadata: {0}", CoauthLockMetadata);
+		}
+	}
 }

--- a/src/WopiValidator.Core/Requests/GetCoauthLockRequest.cs
+++ b/src/WopiValidator.Core/Requests/GetCoauthLockRequest.cs
@@ -1,7 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Office.WopiValidator.Core.IncrementalFileTransfer;
+using Microsoft.Office.WopiValidator.Core.ResourceManagement;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Runtime.Serialization.Json;
+using System.Security.Principal;
+using System.Text;
 
 namespace Microsoft.Office.WopiValidator.Core.Requests
 {
@@ -9,14 +18,17 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 	{
 		public GetCoauthLockRequest(WopiRequestParam param) : base(param)
 		{
-			this.CoauthLockType = param.CoauthLockType;
-			this.CoauthLockMetadata = param.CoauthLockMetadata;
-			this.CoauthLockId = param.CoauthLockId;
-			this.CoauthLockExpirationTimeout = param.CoauthLockExpirationTimeout;
+			CoauthLockType = param.CoauthLockType;
+			CoauthLockMetadata = param.CoauthLockMetadata;
+			CoauthLockId = param.CoauthLockId;
+			CoauthLockExpirationTimeout = param.CoauthLockExpirationTimeout;
+			CoauthLockMetadataAsBody = param.CoauthLockMetadataAsBody;
 		}
 
+		protected override bool HasRequestContent { get { return true; } }
 		public uint? CoauthLockExpirationTimeout { get; private set; }
 		public string CoauthLockMetadata { get; private set; }
+		public CoauthLockMetadataEntity CoauthLockMetadataAsBody { get; private set; }
 		public string CoauthLockId { get; private set; }
 		public CoauthLockType? CoauthLockType { get; private set; }
 		public override string Name { get { return Constants.Requests.GetCoauthLock; } }
@@ -31,7 +43,7 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 			{
 				headers.Add(Constants.Headers.CoauthLockType, CoauthLockType.Value.ToString());
 			}
-			if (CoauthLockMetadata != null)
+			if (CoauthLockMetadataAsBody == null && CoauthLockMetadata != null)
 			{
 				headers.Add(Constants.Headers.CoauthLockMetadata, CoauthLockMetadata);
 			}
@@ -44,6 +56,21 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 				headers.Add(Constants.Headers.CoauthLockExpirationTimeout, CoauthLockExpirationTimeout.Value.ToString());
 			}
 			return headers;
+		}
+
+		protected override MemoryStream GetRequestContent(IResourceManager resourceManager)
+		{
+			if (CoauthLockMetadataAsBody != null)
+			{
+				WopiCoauthLockMetadata metadata = new WopiCoauthLockMetadata();
+				metadata.CoauthLockMetadata = CoauthLockMetadataAsBody.CoauthLockMetadata;
+				byte[] jsonAsBytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(metadata));
+				MemoryStream stream = new MemoryStream(jsonAsBytes);
+				stream.Position = 0;
+				return stream;
+			}
+
+			return null;
 		}
 	}
 }

--- a/src/WopiValidator.Core/Requests/RefreshCoauthLock.cs
+++ b/src/WopiValidator.Core/Requests/RefreshCoauthLock.cs
@@ -1,7 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Office.WopiValidator.Core.IncrementalFileTransfer;
+using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization.Json;
+using System.Text;
 
 namespace Microsoft.Office.WopiValidator.Core.Requests
 {
@@ -9,13 +14,15 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 	{
 		public RefreshCoauthLock(WopiRequestParam param) : base(param)
 		{
-			this.CoauthLockMetadata = param.CoauthLockMetadata;
-			this.CoauthLockId = param.CoauthLockId;
-			this.CoauthLockExpirationTimeout = param.CoauthLockExpirationTimeout;
+			CoauthLockMetadata = param.CoauthLockMetadata;
+			CoauthLockId = param.CoauthLockId;
+			CoauthLockExpirationTimeout = param.CoauthLockExpirationTimeout;
+			CoauthLockMetadataAsBody = param.CoauthLockMetadataAsBody;
 		}
-
+		protected override bool HasRequestContent { get { return true; } }
 		public uint? CoauthLockExpirationTimeout { get; private set; }
 		public string CoauthLockMetadata { get; private set; }
+		public CoauthLockMetadataEntity CoauthLockMetadataAsBody { get; private set; }
 		public string CoauthLockId { get; private set; }
 		public override string Name { get { return Constants.Requests.RefreshCoauthLock; } }
 		protected override string RequestMethod { get { return Constants.RequestMethods.Post; } }
@@ -25,7 +32,7 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 		{
 			Dictionary<string, string> headers = new Dictionary<string, string>();
 
-			if (CoauthLockMetadata != null)
+			if (CoauthLockMetadataAsBody == null && CoauthLockMetadata != null)
 			{
 				headers.Add(Constants.Headers.CoauthLockMetadata, CoauthLockMetadata);
 			}
@@ -38,6 +45,21 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 				headers.Add(Constants.Headers.CoauthLockExpirationTimeout, CoauthLockExpirationTimeout.Value.ToString());
 			}
 			return headers;
+		}
+
+		protected override MemoryStream GetRequestContent(IResourceManager resourceManager)
+		{
+			if (CoauthLockMetadataAsBody != null)
+			{
+				WopiCoauthLockMetadata metadata = new WopiCoauthLockMetadata();
+				metadata.CoauthLockMetadata = CoauthLockMetadataAsBody.CoauthLockMetadata;
+				byte[] jsonAsBytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(metadata));
+				MemoryStream stream = new MemoryStream(jsonAsBytes);
+				stream.Position = 0;
+				return stream;
+			}
+
+			return null;
 		}
 	}
 }

--- a/src/WopiValidator.Core/Requests/WopiRequestParam.cs
+++ b/src/WopiValidator.Core/Requests/WopiRequestParam.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 		public CoauthLockType? CoauthLockType { get; set; }
 		public string CoauthLockMetadata { get; set; }
 		public CoauthLockMetadataEntity CoauthLockMetadataAsBody { get; set; }
-		//public string CoauthLockMetadataAsBody { get; set; }
 		public string Lock { get; set; }
 		public string CoauthLockId { get; set; }
 		public string Editors { get; set; }

--- a/src/WopiValidator.Core/Requests/WopiRequestParam.cs
+++ b/src/WopiValidator.Core/Requests/WopiRequestParam.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 		public string UrlType { get; set; }
 		public CoauthLockType? CoauthLockType { get; set; }
 		public string CoauthLockMetadata { get; set; }
+		public CoauthLockMetadataEntity CoauthLockMetadataAsBody { get; set; }
+		//public string CoauthLockMetadataAsBody { get; set; }
 		public string Lock { get; set; }
 		public string CoauthLockId { get; set; }
 		public string Editors { get; set; }
@@ -60,4 +62,11 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 		CoauthExclusive,
 		None
 	}
+
+	public class CoauthLockMetadataEntity
+	{
+		public string CoauthLockMetadata { get; set; }
+	}
 }
+ 
+

--- a/src/WopiValidator.Core/WopiValidator.Core.csproj
+++ b/src/WopiValidator.Core/WopiValidator.Core.csproj
@@ -23,14 +23,12 @@
 
   <ItemGroup>
     <None Remove="JsonSchemas\CheckFileInfoSchema.json" />
-    <None Remove="JsonSchemas\CoauthLockMetadataSchema.json" />
     <None Remove="JsonSchemas\CoauthTableSchema.json" />
     <None Remove="JsonSchemas\GetChunkedFileResponseSchema.json" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="JsonSchemas\CheckFileInfoSchema.json" />
-    <EmbeddedResource Include="JsonSchemas\CoauthLockMetadataSchema.json" />
     <EmbeddedResource Include="JsonSchemas\CoauthTableSchema.json" />
     <EmbeddedResource Include="JsonSchemas\GetChunkedFileResponseSchema.json" />
     <!-- Excel Zip Chunking Resources -->

--- a/src/WopiValidator.Core/WopiValidator.Core.csproj
+++ b/src/WopiValidator.Core/WopiValidator.Core.csproj
@@ -23,12 +23,14 @@
 
   <ItemGroup>
     <None Remove="JsonSchemas\CheckFileInfoSchema.json" />
+    <None Remove="JsonSchemas\CoauthLockMetadataSchema.json" />
     <None Remove="JsonSchemas\CoauthTableSchema.json" />
     <None Remove="JsonSchemas\GetChunkedFileResponseSchema.json" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="JsonSchemas\CheckFileInfoSchema.json" />
+    <EmbeddedResource Include="JsonSchemas\CoauthLockMetadataSchema.json" />
     <EmbeddedResource Include="JsonSchemas\CoauthTableSchema.json" />
     <EmbeddedResource Include="JsonSchemas\GetChunkedFileResponseSchema.json" />
     <!-- Excel Zip Chunking Resources -->


### PR DESCRIPTION
- Adding sequence number required check
- Fixing IsRequired check that might have failed certain lock operations when the lock is not presented
- Added test cases for coauthlockmetadata change that to pass the metadata as part of the body as well. The change reflects the protocol change to increase reliability of Get/RefreshCoauthLock where the APIs where impacted since certain characters were not allowed as part of the header.