### PR TITLE
Add WebEditingDisabled to CheckFileInfoSchema

### DIFF
--- a/src/WopiValidator.Core/JsonSchemas/CheckFileInfoSchema.json
+++ b/src/WopiValidator.Core/JsonSchemas/CheckFileInfoSchema.json
@@ -256,6 +256,9 @@
     "Version": {
       "type": "string"
     },
+    "WebEditingDisabled": {
+      "type": "boolean"
+    },
     "WorkflowPostMessage": {
       "type": "boolean"
     },

--- a/test/WopiValidator.Core.Tests/Validators/JsonSchemaValidatorUnitTests.cs
+++ b/test/WopiValidator.Core.Tests/Validators/JsonSchemaValidatorUnitTests.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Office.WopiValidator.Core;
+using Microsoft.Office.WopiValidator.Core.Validators;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Office.WopiValidator.UnitTests.Validators
+{
+	[TestClass]
+	public class JsonSchemaValidatorUnitTests
+	{
+		[TestMethod]
+		public void Validate_CheckFileInfoSchema_Succeeds()
+		{
+			string jsonInput =
+				"{\"BaseFileName\": \"dummyFileName\"," +
+				"\"OwnerId\": \"dummyOwnerId\"," +
+				"\"Size\": 100," +
+				"\"UserFriendlyName\": \"dummyUserFriendlyName\"," +
+				"\"UserId\": \"dummyUserId\"," +
+				"\"Version\": \"dummyVersion\"}";
+
+			IResponseData response = new ResponseDataMock
+			{
+				IsTextResponse = true,
+				ResponseContentText = jsonInput,
+			};
+
+			ValidationResult result = new JsonSchemaValidator("CheckFileInfoSchema").Validate(response, null, null);
+			Assert.IsFalse(result.HasFailures);
+		}
+
+		[TestMethod]
+		public void Validate_CheckFileInfoSchema_MissingRequiredFields_Fails()
+		{
+			string jsonInput =
+				"{\"BaseFileName\": \"dummyFileName\"," +
+				"\"OwnerId\": \"dummyOwnerId\"," +
+				"\"Size\": 100," +
+				"\"UserFriendlyName\": \"dummyUserFriendlyName\"," +
+				"\"Version\": \"dummyVersion\"}";
+
+			IResponseData response = new ResponseDataMock
+			{
+				IsTextResponse = true,
+				ResponseContentText = jsonInput,
+			};
+
+			ValidationResult result = new JsonSchemaValidator("CheckFileInfoSchema").Validate(response, null, null);
+			Assert.IsTrue(result.HasFailures);
+		}
+
+		[TestMethod]
+		public void Validate_CheckFileInfoSchema_WrongRequiredFields_Fails()
+		{
+			string jsonInput =
+				"{\"BaseFileNameppppppp\": \"dummyFileName\"," +
+				"\"OwnerId\": \"dummyOwnerId\"," +
+				"\"Size\": 100," +
+				"\"UserFriendlyName\": \"dummyUserFriendlyName\"," +
+				"\"UserId\": \"dummyUserId\"," +
+				"\"Version\": \"dummyVersion\"}";
+
+			IResponseData response = new ResponseDataMock
+			{
+				IsTextResponse = true,
+				ResponseContentText = jsonInput,
+			};
+
+			ValidationResult result = new JsonSchemaValidator("CheckFileInfoSchema").Validate(response, null, null);
+			Assert.IsTrue(result.HasFailures);
+		}
+
+		[TestMethod]
+		public void Validate_CheckFileInfoSchema_UndefinedOptionalFields_Fails()
+		{
+			string jsonInput =
+				"{\"BaseFileName\": \"dummyFileName\"," +
+				"\"OwnerId\": \"dummyOwnerId\"," +
+				"\"Size\": 100," +
+				"\"UserFriendlyName\": \"dummyUserFriendlyName\"," +
+				"\"UserId\": \"dummyUserId\"," +
+				"\"Version\": \"dummyVersion\"," +
+				"\"xxx\": \"xxx\"}";
+
+			IResponseData response = new ResponseDataMock
+			{
+				IsTextResponse = true,
+				ResponseContentText = jsonInput,
+			};
+
+			ValidationResult result = new JsonSchemaValidator("CheckFileInfoSchema").Validate(response, null, null);
+			Assert.IsTrue(result.HasFailures);
+		}
+
+		[TestMethod]
+		public void Validate_CheckFileInfoSchema_DefinedOptionalFields_Succeeds()
+		{
+			string jsonInput =
+				"{\"BaseFileName\": \"dummyFileName\"," +
+				"\"OwnerId\": \"dummyOwnerId\"," +
+				"\"Size\": 100," +
+				"\"UserFriendlyName\": \"dummyUserFriendlyName\"," +
+				"\"UserId\": \"dummyUserId\"," +
+				"\"Version\": \"dummyVersion\"," +
+				"\"WebEditingDisabled\": \"false\"}";
+
+			IResponseData response = new ResponseDataMock
+			{
+				IsTextResponse = true,
+				ResponseContentText = jsonInput,
+			};
+
+			ValidationResult result = new JsonSchemaValidator("CheckFileInfoSchema").Validate(response, null, null);
+			Assert.IsTrue(result.HasFailures);
+		}
+	}
+}

--- a/test/WopiValidator.Core.Tests/Validators/JsonSchemaValidatorUnitTests.cs
+++ b/test/WopiValidator.Core.Tests/Validators/JsonSchemaValidatorUnitTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Office.WopiValidator.UnitTests.Validators
 				"\"UserFriendlyName\": \"dummyUserFriendlyName\"," +
 				"\"UserId\": \"dummyUserId\"," +
 				"\"Version\": \"dummyVersion\"," +
-				"\"WebEditingDisabled\": \"false\"}";
+				"\"WebEditingDisabled\": false}";
 
 			IResponseData response = new ResponseDataMock
 			{
@@ -113,7 +113,7 @@ namespace Microsoft.Office.WopiValidator.UnitTests.Validators
 			};
 
 			ValidationResult result = new JsonSchemaValidator("CheckFileInfoSchema").Validate(response, null, null);
-			Assert.IsTrue(result.HasFailures);
+			Assert.IsFalse(result.HasFailures);
 		}
 	}
 }


### PR DESCRIPTION
WebEditingDisabled is an optional property of CheckFileInfo as per
* https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/rest/files/checkfileinfo/checkfileinfo-other#webeditingdisabled

We need to add it, otherwise hosts which return this property will fail FullCheckFileInfoSchema test: https://github.com/microsoft/wopi-validator-core/blob/4c995a0d8c32ed5f55cac1dd3209d2450e12725c/TestCases.xml#L490