### PR TITLE
Re-add missing properties in CheckFileInfoSchema

### DIFF
--- a/src/WopiValidator.Core/JsonSchemas/CheckFileInfoSchema.json
+++ b/src/WopiValidator.Core/JsonSchemas/CheckFileInfoSchema.json
@@ -500,6 +500,34 @@
             },
             { "type": "null" }
           ]
+        },
+        "AppStateHistoryPostMessage": {
+          "type": "boolean"
+        },
+        "ClosePostMessage": {
+          "type": "boolean"
+        },
+        "EditModePostMessage": {
+          "type": "boolean"
+        },
+        "EditNotificationPostMessage": {
+          "type": "boolean"
+        },
+        "FileEmbedCommandPostMessage": {
+          "type": "boolean"
+        },
+        "FileSharingPostMessage": {
+          "type": "boolean"
+        },
+        "FileVersionPostMessage": {
+          "type": "boolean"
+        },
+        "PostMessageOrigin": {
+          "type": "string",
+          "format": "uri"
+        },
+        "WorkflowPostMessage": {
+          "type": "boolean"
         }
       }
     },
@@ -1060,6 +1088,34 @@
             },
             { "type": "null" }
           ]
+        },
+        "AppStateHistoryPostMessage": {
+          "type": "boolean"
+        },
+        "ClosePostMessage": {
+          "type": "boolean"
+        },
+        "EditModePostMessage": {
+          "type": "boolean"
+        },
+        "EditNotificationPostMessage": {
+          "type": "boolean"
+        },
+        "FileEmbedCommandPostMessage": {
+          "type": "boolean"
+        },
+        "FileSharingPostMessage": {
+          "type": "boolean"
+        },
+        "FileVersionPostMessage": {
+          "type": "boolean"
+        },
+        "PostMessageOrigin": {
+          "type": "string",
+          "format": "uri"
+        },
+        "WorkflowPostMessage": {
+          "type": "boolean"
         }
       }
     }


### PR DESCRIPTION
resolve #132

Re-adding missing properties related to PostMessage in CheckFileInfoSchema. These refer to properties that existed in a previous commit but have since been removed.

ref: https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/online/scenarios/customization#postmessage-properties
ref: https://github.com/microsoft/wopi-validator-core/blob/7a27d9c75fc0d86036cc2d5b55b224fa60346464/src/WopiValidator.Core/JsonSchemas/CheckFileInfoSchema.json