### PR TITLE
Stop following redirects.

### DIFF
--- a/src/WopiValidator.Core/Requests/RequestBase.cs
+++ b/src/WopiValidator.Core/Requests/RequestBase.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 
 			HttpWebRequest request = WebRequest.CreateHttp(executionData.TargetUri);
 			request.UserAgent = userAgent;
+			request.AllowAutoRedirect = false;
 
 			// apply custom headers
 			foreach (KeyValuePair<string, string> header in RequestHeaders)


### PR DESCRIPTION
Update the validator to stop following 3xx http status codes since those are not part of the WOPI protocol.