### PR TITLE
Pass in flag to hide sensitive info (proof key) + build for .NET 10 + bump version to 2.0.6

### DIFF
--- a/src/WopiValidator.Core/Constants.cs
+++ b/src/WopiValidator.Core/Constants.cs
@@ -209,5 +209,7 @@ namespace Microsoft.Office.WopiValidator.Core
 			public const string FileStream = "FileStream";
 			public const string ZeroByteOfficeDocumentResourceId = "ZeroByteOfficeDocument";
 		}
+
+		public static string HideSensitiveInfoNotice = "*** SENSITIVE INFO HIDDEN IN WOPIVALIDATOR ***";
 	}
 }

--- a/src/WopiValidator.Core/IWopiRequest.cs
+++ b/src/WopiValidator.Core/IWopiRequest.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Office.WopiValidator.Core
 			IResourceManager resourceManager,
 			string userAgent,
 			RSACryptoServiceProvider proofKeyProviderNew,
-			RSACryptoServiceProvider proofKeyProviderOld);
+			RSACryptoServiceProvider proofKeyProviderOld,
+			bool hideSensitiveInfo);
 	}
 }

--- a/src/WopiValidator.Core/Requests/GetFromFileUrlRequest.cs
+++ b/src/WopiValidator.Core/Requests/GetFromFileUrlRequest.cs
@@ -34,7 +34,8 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 			IResourceManager resourceManager,
 			string userAgent,
 			RSACryptoServiceProvider proofKeyProviderNew,
-			RSACryptoServiceProvider proofKeyProviderOld)
+			RSACryptoServiceProvider proofKeyProviderOld,
+			bool hideSensitiveInfo)
 		{
 			RequestExecutionData executionData = new RequestExecutionData(
 				new Uri(GetEndpointAddressOverride(savedState)),

--- a/src/WopiValidator.Core/Requests/GetFromFileUrlRequest.cs
+++ b/src/WopiValidator.Core/Requests/GetFromFileUrlRequest.cs
@@ -55,7 +55,8 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 			IResourceManager resourceManager,
 			string userAgent,
 			RSACryptoServiceProvider proofKeyProviderNew,
-			RSACryptoServiceProvider proofKeyProviderOld)
+			RSACryptoServiceProvider proofKeyProviderOld,
+			bool hideSensitiveInfo)
 		{
 			RequestExecutionData executionData = new RequestExecutionData(
 				new Uri(GetEndpointAddressOverride(savedState)),

--- a/src/WopiValidator.Core/Requests/RequestBase.cs
+++ b/src/WopiValidator.Core/Requests/RequestBase.cs
@@ -184,6 +184,7 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 			IResourceManager resourceManager,
 			string userAgent,
 			RSACryptoServiceProvider proofKeyProviderNew,
-			RSACryptoServiceProvider proofKeyProviderOld);
+			RSACryptoServiceProvider proofKeyProviderOld,
+			bool hideSensitiveInfo);
 	}
 }

--- a/src/WopiValidator.Core/Requests/WopiRequest.cs
+++ b/src/WopiValidator.Core/Requests/WopiRequest.cs
@@ -69,7 +69,8 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 			IResourceManager resourceManager,
 			string userAgent,
 			RSACryptoServiceProvider proofKeyProviderNew,
-			RSACryptoServiceProvider proofKeyProviderOld)
+			RSACryptoServiceProvider proofKeyProviderOld,
+			bool hideSensitiveInfo)
 		{
 			// Get the url of the WOPI endpoint that we'll call - either the normal endpoint, or a SavedState override.
 			// If it's an override it might change the accessToken that we're using because it probably already has a token on it.
@@ -95,9 +96,9 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 			if (proofKeyProviderNew != null && proofKeyProviderOld != null)
 			{
 				Dictionary<string, string> originalProofKeyHeaders =
-					GetProofKeyHeaders(accessTokenToUse, uri, proofKeyProviderNew, proofKeyProviderOld);
+					GetProofKeyHeaders(accessTokenToUse, uri, proofKeyProviderNew, proofKeyProviderOld, hideSensitiveInfo);
 				Dictionary<string, string> proofKeyHeadersToUse =
-					GetMutatedProofKeyHeaders(originalProofKeyHeaders, timestamp => GetProofKeyHeaders(accessTokenToUse, uri, proofKeyProviderNew, proofKeyProviderOld, timestamp));
+					GetMutatedProofKeyHeaders(originalProofKeyHeaders, timestamp => GetProofKeyHeaders(accessTokenToUse, uri, proofKeyProviderNew, proofKeyProviderOld, hideSensitiveInfo));
 				headers.AddRange(proofKeyHeadersToUse);
 			}
 
@@ -179,7 +180,8 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 			Uri endpointUri,
 			RSACryptoServiceProvider proofKeyProviderNew,
 			RSACryptoServiceProvider proofKeyProviderOld,
-			long timestamp)
+			long timestamp,
+			bool hideSensitiveInfo)
 		{
 			Dictionary<string, string> proofKeyHeaders = new Dictionary<string, string>();
 
@@ -197,6 +199,12 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 			proofKeyHeaders.Add(Constants.Headers.WopiTimestamp, timestamp.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
 			// save the proof key output to help partners investigate proof key implementation bugs
+			if (hideSensitiveInfo)
+			{
+				currentProof.SignedBase64ProofKey = "*** SENSITIVE INFO HIDDEN IN WOPIVALIDATOR ***";
+				oldProof.SignedBase64ProofKey = "*** SENSITIVE INFO HIDDEN IN WOPIVALIDATOR ***";
+			}
+
 			this.CurrentProofData = currentProof;
 			this.OldProofData = oldProof;
 
@@ -206,9 +214,10 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 		private Dictionary<string, string> GetProofKeyHeaders(string accessToken,
 			Uri endpointUri,
 			RSACryptoServiceProvider proofKeyProviderNew,
-			RSACryptoServiceProvider proofKeyProviderOld)
+			RSACryptoServiceProvider proofKeyProviderOld,
+			bool hideSensitiveInfo)
 		{
-			return GetProofKeyHeaders(accessToken, endpointUri, proofKeyProviderNew, proofKeyProviderOld, DateTime.UtcNow.Ticks);
+			return GetProofKeyHeaders(accessToken, endpointUri, proofKeyProviderNew, proofKeyProviderOld, DateTime.UtcNow.Ticks, hideSensitiveInfo);
 		}
 
 		private string GetMutatedAccessToken(string original)

--- a/src/WopiValidator.Core/Requests/WopiRequest.cs
+++ b/src/WopiValidator.Core/Requests/WopiRequest.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 				Dictionary<string, string> originalProofKeyHeaders =
 					GetProofKeyHeaders(accessTokenToUse, uri, proofKeyProviderNew, proofKeyProviderOld, hideSensitiveInfo);
 				Dictionary<string, string> proofKeyHeadersToUse =
-					GetMutatedProofKeyHeaders(originalProofKeyHeaders, timestamp => GetProofKeyHeaders(accessTokenToUse, uri, proofKeyProviderNew, proofKeyProviderOld, hideSensitiveInfo));
+					GetMutatedProofKeyHeaders(originalProofKeyHeaders, timestamp => GetProofKeyHeaders(accessTokenToUse, uri, proofKeyProviderNew, proofKeyProviderOld, timestamp, hideSensitiveInfo));
 				headers.AddRange(proofKeyHeadersToUse);
 			}
 
@@ -201,8 +201,8 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 			// save the proof key output to help partners investigate proof key implementation bugs
 			if (hideSensitiveInfo)
 			{
-				currentProof.SignedBase64ProofKey = "*** SENSITIVE INFO HIDDEN IN WOPIVALIDATOR ***";
-				oldProof.SignedBase64ProofKey = "*** SENSITIVE INFO HIDDEN IN WOPIVALIDATOR ***";
+				currentProof.SignedBase64ProofKey = Constants.HideSensitiveInfoNotice;
+				oldProof.SignedBase64ProofKey = Constants.HideSensitiveInfoNotice;
 			}
 
 			this.CurrentProofData = currentProof;

--- a/src/WopiValidator.Core/Requests/WopiRequest.cs
+++ b/src/WopiValidator.Core/Requests/WopiRequest.cs
@@ -73,7 +73,16 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 			RSACryptoServiceProvider proofKeyProviderOld,
 			bool hideSensitiveInfo)
 		{
-			RequestExecutionData executionData = CreateExecutionData(endpointAddress, ref accessToken, accessTokenTtl, savedState, resourceManager, proofKeyProviderNew, proofKeyProviderOld);
+			RequestExecutionData executionData = CreateExecutionData(
+				endpointAddress,
+				ref accessToken,
+				accessTokenTtl,
+				savedState,
+				resourceManager,
+				proofKeyProviderNew,
+				proofKeyProviderOld,
+				hideSensitiveInfo);
+
 			return ExecuteRequest(executionData, userAgent);
 		}
 
@@ -88,13 +97,31 @@ namespace Microsoft.Office.WopiValidator.Core.Requests
 			IResourceManager resourceManager,
 			string userAgent,
 			RSACryptoServiceProvider proofKeyProviderNew,
-			RSACryptoServiceProvider proofKeyProviderOld)
+			RSACryptoServiceProvider proofKeyProviderOld,
+			bool hideSensitiveInfo)
 		{
-			RequestExecutionData executionData = CreateExecutionData(endpointAddress, ref accessToken, accessTokenTtl, savedState, resourceManager, proofKeyProviderNew, proofKeyProviderOld);
+			RequestExecutionData executionData = CreateExecutionData(
+				endpointAddress,
+				ref accessToken,
+				accessTokenTtl,
+				savedState,
+				resourceManager,
+				proofKeyProviderNew,
+				proofKeyProviderOld,
+				hideSensitiveInfo);
+
 			return await ExecuteRequestAsync(executionData, userAgent).ConfigureAwait(false);
 		}
 
-		private RequestExecutionData CreateExecutionData(string endpointAddress, ref string accessToken, long accessTokenTtl, Dictionary<string, string> savedState, IResourceManager resourceManager, RSACryptoServiceProvider proofKeyProviderNew, RSACryptoServiceProvider proofKeyProviderOld)
+		private RequestExecutionData CreateExecutionData(
+			string endpointAddress,
+			ref string accessToken,
+			long accessTokenTtl,
+			Dictionary<string, string> savedState,
+			IResourceManager resourceManager,
+			RSACryptoServiceProvider proofKeyProviderNew,
+			RSACryptoServiceProvider proofKeyProviderOld,
+			bool hideSensitiveInfo)
 		{
 			// Get the url of the WOPI endpoint that we'll call - either the normal endpoint, or a SavedState override.
 			// If it's an override it might change the accessToken that we're using because it probably already has a token on it.

--- a/src/WopiValidator.Core/TestCaseExecutor.cs
+++ b/src/WopiValidator.Core/TestCaseExecutor.cs
@@ -223,7 +223,8 @@ namespace Microsoft.Office.WopiValidator.Core
 							ResourceManager,
 							UserAgent,
 							ProofKeyProviderNew,
-							ProofKeyProviderOld).ConfigureAwait(false);
+							ProofKeyProviderOld,
+							HideSensitiveInfo).ConfigureAwait(false);
 					}
 					catch (ProofKeySigningException ex)
 					{
@@ -269,7 +270,7 @@ namespace Microsoft.Office.WopiValidator.Core
 					// Save any state that was requested
 					foreach (IStateEntry stateSaver in request.State)
 					{
-						savedState[ stateSaver.Name ] = stateSaver.GetValue(responseData);
+						savedState[stateSaver.Name] = stateSaver.GetValue(responseData);
 					}
 				}
 			}
@@ -405,7 +406,8 @@ namespace Microsoft.Office.WopiValidator.Core
 						ResourceManager,
 						UserAgent,
 						ProofKeyProviderNew,
-						ProofKeyProviderOld).ConfigureAwait(false);
+						ProofKeyProviderOld,
+						HideSensitiveInfo).ConfigureAwait(false);
 
 					// No validators needed, they're just cleanup and we don't care if they worked or not.
 

--- a/src/WopiValidator.Core/TestCaseExecutor.cs
+++ b/src/WopiValidator.Core/TestCaseExecutor.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Office.WopiValidator.Core
 			long accessTokenTtl,
 			string userAgent,
 			RSACryptoServiceProvider proofKeyProviderNew = null,
-			RSACryptoServiceProvider proofKeyProviderOld = null)
+			RSACryptoServiceProvider proofKeyProviderOld = null,
+			bool hideSensitiveInfo = false)
 		{
 			TestCase = executionData.TestCase;
 			PrereqCases = executionData.PrereqCases;
@@ -36,6 +37,7 @@ namespace Microsoft.Office.WopiValidator.Core
 			UserAgent = userAgent;
 			ProofKeyProviderNew = proofKeyProviderNew;
 			ProofKeyProviderOld = proofKeyProviderOld;
+			HideSensitiveInfo = hideSensitiveInfo;
 		}
 
 		public ITestCase TestCase { get; private set; }
@@ -47,6 +49,7 @@ namespace Microsoft.Office.WopiValidator.Core
 		public string UserAgent { get; private set; }
 		public RSACryptoServiceProvider ProofKeyProviderNew { get; private set; }
 		public RSACryptoServiceProvider ProofKeyProviderOld { get; private set; }
+		public bool HideSensitiveInfo { get; private set; }
 
 		public TestCaseResult Execute()
 		{
@@ -100,7 +103,8 @@ namespace Microsoft.Office.WopiValidator.Core
 							ResourceManager,
 							UserAgent,
 							ProofKeyProviderNew,
-							ProofKeyProviderOld);
+							ProofKeyProviderOld,
+							HideSensitiveInfo);
 					}
 					catch (ProofKeySigningException ex)
 					{
@@ -222,7 +226,8 @@ namespace Microsoft.Office.WopiValidator.Core
 						ResourceManager,
 						UserAgent,
 						ProofKeyProviderNew,
-						ProofKeyProviderOld);
+						ProofKeyProviderOld,
+						HideSensitiveInfo);
 
 					// No validators needed, they're just cleanup and we don't care if they worked or not.
 

--- a/src/WopiValidator.Core/WopiValidator.Core.csproj
+++ b/src/WopiValidator.Core/WopiValidator.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net45;net6.0;net8.0;net10.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../WopiValidatorSigningKey.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
@@ -16,10 +16,10 @@
     <Description>Core library for WOPI validation: parses XML tests, executes WOPI requests, signs proofs, mutates tokens, captures state, runs validators, handles chunked (full/zip) transfer. Targets .NET 4.5/6.0/8.0. For testing only.</Description>
     <PackageTags>wopi;wopiplus;cspp;csppplus</PackageTags>
     <PackageId>WopiValidator.Core</PackageId>
-    <PackageVersion>2.0.5</PackageVersion>
+    <PackageVersion>2.0.6</PackageVersion>
     <Product>WopiValidator.Core</Product>
     <Copyright>Microsoft</Copyright>
-    <Version>2.0.5</Version>
+    <Version>2.0.6</Version>
     <Title>WOPI Validator Core Engine</Title>
     <PackageProjectUrl>https://github.com/microsoft/wopi-validator-core/tree/main/src/WopiValidator.Core</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/WopiValidator.Core/WopiValidator.Core.csproj
+++ b/src/WopiValidator.Core/WopiValidator.Core.csproj
@@ -13,7 +13,8 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
-    <Description>Core library for WOPI validation: parses XML tests, executes WOPI requests, signs proofs, mutates tokens, captures state, runs validators, handles chunked (full/zip) transfer. Targets .NET 4.5/6.0/8.0. For testing only.</Description>
+    <Description>Core library for WOPI validation: parses XML tests, executes WOPI requests, signs proofs, mutates tokens, captures state, runs validators, handles chunked (full/zip) transfer.
+    Targets .NET 45/6.0/8.0/10.0. For testing only.</Description>
     <PackageTags>wopi;wopiplus;cspp;csppplus</PackageTags>
     <PackageId>WopiValidator.Core</PackageId>
     <PackageVersion>2.0.6</PackageVersion>

--- a/src/WopiValidator/WopiValidator.csproj
+++ b/src/WopiValidator/WopiValidator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net45;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net45;net6.0;net8.0;net10.0</TargetFrameworks>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../WopiValidatorSigningKey.snk</AssemblyOriginatorKeyFile>
@@ -22,10 +22,10 @@ Targets .NET 4.5/6.0/8.0. For validation only.
     </Description>
     <PackageTags>wopi;wopiplus;cspp;csppplus</PackageTags>
     <PackageId>WopiValidator</PackageId>
-    <PackageVersion>2.0.5</PackageVersion>
+    <PackageVersion>2.0.6</PackageVersion>
     <Product>WopiValidator</Product>
     <Copyright>Microsoft</Copyright>
-    <Version>2.0.5</Version>
+    <Version>2.0.6</Version>
     <Title>WOPI host compliance CLI</Title>
     <PackageProjectUrl>https://github.com/microsoft/wopi-validator-core/tree/main/src/WopiValidator</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/WopiValidator/WopiValidator.csproj
+++ b/src/WopiValidator/WopiValidator.csproj
@@ -18,7 +18,7 @@
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <Description>Runs an XML test suite and outputs pass/fail diagnostics.
-Targets .NET 4.5/6.0/8.0. For validation only.
+Targets .NET 45/6.0/8.0/10.0. For validation only.
     </Description>
     <PackageTags>wopi;wopiplus;cspp;csppplus</PackageTags>
     <PackageId>WopiValidator</PackageId>


### PR DESCRIPTION
⁠What:
Adds a hideSensitiveInfo flag that replaces proof key signatures in output with *** SENSITIVE INFO HIDDEN IN WOPIVALIDATOR *** instead of exposing actual signed base64 proof keys. Also bumps version to 2.0.6 and adds .NET 10.0 target.

Leak path:

1. WopiRequest.GetProofKeyHeaders() generates proof key signatures and stores them in request.CurrentProofData / request.OldProofData (including the raw SignedBase64ProofKey)
2. TestCaseExecutor packages those into RequestInfo objects as part of test results
3. RequestInfo is returned in TestCaseResult.RequestDetails
4. The consuming UI renders the full RequestInfo — including the signed proof keys — to help partners debug proof key validation issues